### PR TITLE
Replace topological sort 

### DIFF
--- a/R/graph_methods.R
+++ b/R/graph_methods.R
@@ -55,7 +55,7 @@ topological_sort <- function(graph) {
   }
 
   if (visited != length(in_degrees)) {
-    stop("Graph is not a directed acyclic graph. Cycles involving nodes: ",
+    stop("Dependency graph is not a directed acyclic graph. Cycles involving: ",
          paste0(setdiff(names(in_degrees), sorted), collapse = " "))
   } else {
     return(unlist(sorted))

--- a/R/graph_methods.R
+++ b/R/graph_methods.R
@@ -1,51 +1,65 @@
-#' Topologically sorts nodes so that parents are listed before all their children
 #'
-#' @param child_to_parents  mapping from child to its parents (upstream dependencies)
+#' Topological graph sort
 #'
+#' Graph is a list which for each node contains a vector of child nodes
+#' in the returned list, parents appear before their children.
+#'
+#' Implementation of Kahn algorithm with a modification to maintain the order of input elements.
+#'
+#' @param graph (named `list`) list with node vector elements mapping from
+#'   child to its parents (upstream dependencies)
 #' @return vector listing parents before children
-#'
 #' @examples
-#' topological_sort <- staged.dependencies:::topological_sort
-#'
-#' all(topological_sort(list(
-#' n1 = c(), n2 = c("n1"), n3 = c("n2"),
-#' n4 = c("n2", "n3"))) == c("n1", "n2", "n3", "n4")
-#' )
-#' is.null(topological_sort(list()))
-#'
+#'   staged.dependencies:::topological_sort(list(A = c(), B = c("A"), C = c("B"), D = c("A")))
+#'   staged.dependencies:::topological_sort(list(D = c("A"), A = c(), B = c("A"), C = c("B")))
+#'   staged.dependencies:::topological_sort(list(D = c("A"), B = c("A"), C = c("B"), A = c()))
 #' \dontrun{
-#' # cycle
-#' topological_sort(list(
-#'   n1 = c("n2"), n2 = c("n3", "n1"), n3 = c()
-#' ))
+#'   # cycle
+#'   topological_sort(list(A = c("B"), B = c("C", "A"), C = c()))
 #' }
-topological_sort <- function(child_to_parents) {
-  # depth-first search from children to parents, then output nodes in the order of finishing times
-  ordering <- c()
-  visiting <- list()
-
-  treat_node <- function(node) {
-    # cat_nl("Treating node '", node, "'")
-    # Sys.sleep(1)
-    # print(visiting)
-    if (node %in% names(visiting)) {
-      stop("Node ", node, " forms part of a cycle.")
+topological_sort <- function(graph) {
+  # compute in-degrees
+  in_degrees <- list()
+  for (node in names(graph)) {
+    in_degrees[[node]] <- 0
+    for (to_edge in graph[[node]]) {
+      in_degrees[[to_edge]] <- 0
     }
-    visiting[[node]] <<- TRUE
-    for (parent in setdiff(child_to_parents[[node]], ordering)) {
-      treat_node(parent)
-    }
-    visiting[[node]] <<- NULL # remove
-    ordering <<- c(ordering, node)
   }
 
-  nodes_to_process <- names(child_to_parents)
-  while (length(nodes_to_process) > 0) {
-    treat_node(nodes_to_process[[1]])
-    nodes_to_process <- setdiff(nodes_to_process, ordering)
+  for (node in graph) {
+    for (to_edge in node) {
+      in_degrees[[to_edge]] <- in_degrees[[to_edge]] + 1
+    }
   }
 
-  ordering
+  # sort
+  visited <- 0
+  sorted <- list()
+  zero_in <- list()
+  for (node in names(in_degrees)) {
+    if (in_degrees[[node]] == 0) zero_in <- append(zero_in, node)
+  }
+  zero_in <- rev(zero_in)
+
+  while (length(zero_in) != 0) {
+    visited <- visited + 1
+    sorted <- c(zero_in[[1]], sorted)
+    for (edge_to in graph[[zero_in[[1]]]]) {
+      in_degrees[[edge_to]] <- in_degrees[[edge_to]] - 1
+      if (in_degrees[[edge_to]] == 0) {
+        zero_in <- append(zero_in, edge_to, 1)
+      }
+    }
+    zero_in[[1]] <- NULL
+  }
+
+  if (visited != length(in_degrees)) {
+    stop("Graph is not a directed acyclic graph. Cycles involving nodes: ",
+         paste0(setdiff(names(in_degrees), sorted), collapse = " "))
+  } else {
+    return(unlist(sorted))
+  }
 }
 
 # get the descendants (all children) of node, given list mapping parent to children

--- a/man/determine_branch.Rd
+++ b/man/determine_branch.Rd
@@ -9,7 +9,7 @@ determine_branch(feature, available_branches, branch_sep = "@")
 \arguments{
 \item{feature}{feature we want to build, includes fallbacks}
 
-\item{available_branches}{branches to search in}
+\item{available_branches}{branches to search in, adds \code{main} branch last}
 
 \item{branch_sep}{separator between branches in \code{feature}, \code{/} does not
 work well with \code{git} because it clashes with the filesystem paths}

--- a/man/topological_sort.Rd
+++ b/man/topological_sort.Rd
@@ -2,32 +2,30 @@
 % Please edit documentation in R/graph_methods.R
 \name{topological_sort}
 \alias{topological_sort}
-\title{Topologically sorts nodes so that parents are listed before all their children}
+\title{Topological graph sort}
 \usage{
-topological_sort(child_to_parents)
+topological_sort(graph)
 }
 \arguments{
-\item{child_to_parents}{mapping from child to its parents (upstream dependencies)}
+\item{graph}{(named `list`) list with node vector elements mapping from
+child to its parents (upstream dependencies)}
 }
 \value{
 vector listing parents before children
 }
 \description{
-Topologically sorts nodes so that parents are listed before all their children
+Graph is a list which for each node contains a vector of child nodes
+in the returned list, parents appear before their children.
+}
+\details{
+Implementation of Kahn algorithm with a modification to maintain the order of input elements.
 }
 \examples{
-topological_sort <- staged.dependencies:::topological_sort
-
-all(topological_sort(list(
-n1 = c(), n2 = c("n1"), n3 = c("n2"),
-n4 = c("n2", "n3"))) == c("n1", "n2", "n3", "n4")
-)
-is.null(topological_sort(list()))
-
+  staged.dependencies:::topological_sort(list(A = c(), B = c("A"), C = c("B"), D = c("A")))
+  staged.dependencies:::topological_sort(list(D = c("A"), A = c(), B = c("A"), C = c("B")))
+  staged.dependencies:::topological_sort(list(D = c("A"), B = c("A"), C = c("B"), A = c()))
 \dontrun{
-# cycle
-topological_sort(list(
-  n1 = c("n2"), n2 = c("n3", "n1"), n3 = c()
-))
+  # cycle
+  topological_sort(list(A = c("B"), B = c("C", "A"), C = c()))
 }
 }

--- a/tests/testthat/test-topological_sort.R
+++ b/tests/testthat/test-topological_sort.R
@@ -1,0 +1,80 @@
+test_that("topological sort throws error if circular relationship", {
+
+  expect_error(topological_sort(
+    list(n1 = "n3", n2 = "n2", n3 = c(""))
+  ))
+
+  expect_error(topological_sort(
+    list(n1 = "n2", n2 = "n1")
+  ))
+
+  expect_error(topological_sort(
+    list(n1 = "n2", n2 = "n3", n3 = c("n4", "n1"), n4 = c())
+  ))
+
+})
+
+test_that("topological sort correctly sorts graph with no branching", {
+  sorted_deps <- topological_sort(
+    list(
+      n1 = "n2",
+      n2 = "n4",
+      n3 = "n5",
+      n4 = "n3",
+      n5 = c()
+    )
+  )
+  expect_equal(sorted_deps, c("n5", "n3", "n4", "n2", "n1"))
+})
+
+test_that("topological sort correctly sorts disconnected graph", {
+  sorted_deps <- topological_sort(
+    list(
+      n1 = "n2",
+      n2 = "n4",
+      n3 = "n5",
+      n4 = c(),
+      n5 = c()
+    )
+  )
+
+  expect_true(which(sorted_deps == "n2") < which(sorted_deps == "n1"))
+  expect_true(which(sorted_deps == "n4") < which(sorted_deps == "n2"))
+  expect_true(which(sorted_deps == "n5") < which(sorted_deps == "n3"))
+  expect_equal(length(sorted_deps), 5)
+  expect_equal(unique(sorted_deps), sorted_deps)
+})
+
+test_that("topological sort works with graph with branching", {
+  sorted_deps <- topological_sort(
+    list(
+      n1 = "n3",
+      n2 = c("n1", "n4"),
+      n3 = c(),
+      n4 = "n3"
+    )
+  )
+
+  expect_equal(length(sorted_deps), 4)
+  expect_equal(unique(sorted_deps), sorted_deps)
+  expect_equal(sorted_deps[1], "n3")
+  expect_equal(sorted_deps[4], "n2")
+  expect_equal(sort(sorted_deps[2:3]), c("n1", "n4")) # ordering of these does not matter
+})
+
+
+test_that("topological sort works when parent occurs twice in graph", {
+  sorted_deps <- topological_sort(
+    list(
+      n1 = c("n2", "n3", "n4", "n5"),
+      n2 = c(),
+      n3 = c("n4"),
+      n4 = c(),
+      n5 = c("n6"),
+      n6 = c()
+    )
+  )
+  expect_equal(sorted_deps, c("n2", "n4", "n3", "n6", "n5", "n1"))
+})
+
+


### PR DESCRIPTION
Closes #21 (does not address #38)

Replace topological sort with non-recursive version from teal and added tests

Also test by adding test.nest into tern's staged_dependencies.yaml file

@waddella - after this we should revert the commits which changed the yaml files in NEST package and retest.