### PR TITLE
improve error message when a yaml file has an incorrect upstream repo

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -110,7 +110,14 @@ install_deps <- function(project = ".", feature = NULL,
   install_order <- get_install_order(deps[["upstream_deps"]])
   if (identical(direction, "upstream")) {
     # if installing upstream dependencies, project should appear last
-    stopifnot(all.equal(utils::tail(install_order, 1)[[1]], repo_deps_info$current_repo))
+    if (!isTRUE(all.equal(utils::tail(install_order, 1)[[1]], repo_deps_info$current_repo))){
+      stop("The staged dependency yaml files of your packages imply ",
+           utils::tail(install_order, 1)[[1]]$repo,
+           " is an upstream dependency of ",
+           repo_deps_info$current_repo$repo,
+           "; however the R package DESCRIPTION files do not agree ",
+           "please fix and re-run the command")
+    }
   }
   if (!install_project) {
     install_order <- utils::head(install_order, -1)


### PR DESCRIPTION
So this closes #59 (this only closes the specific case mentioned there by improving the error message)

Test by adding say rcd into osprey's yaml file as an upstream repo:
![image](https://user-images.githubusercontent.com/15201933/129025708-5cf5a9a7-7df2-4ab0-bc84-56acd4fa857d.png)
