### PR TITLE
allow option to skip checks if yaml file missing

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -505,7 +505,7 @@ build_check_install <- function(dep_structure,
 #'
 #' @param dep_structure `dependency_structure` object
 #' @param skip_if_missing_yaml `logical` should checks be skipped on packages
-#'   without yaml files. Default `TRUE`
+#'   without yaml files. Default `FALSE`
 #' @return NULL if successful. An error is thrown if inconsistencies found
 #' @export
 #'
@@ -514,7 +514,7 @@ build_check_install <- function(dep_structure,
 #' x <- dependency_table(project = ".")
 #' check_yamls_consistent(x)
 #' }
-check_yamls_consistent <- function(dep_structure, skip_if_missing_yaml = TRUE) {
+check_yamls_consistent <- function(dep_structure, skip_if_missing_yaml = FALSE) {
 
   stopifnot(methods::is(dep_structure, "dependency_structure"))
   stopifnot(setequal(dep_structure$direction, c("upstream", "downstream")))

--- a/man/check_yamls_consistent.Rd
+++ b/man/check_yamls_consistent.Rd
@@ -5,10 +5,13 @@
 \title{Checks that the staged dependency yamls are consistent with
 the dependencies listed in the DESCRIPTION files}
 \usage{
-check_yamls_consistent(dep_structure)
+check_yamls_consistent(dep_structure, skip_if_missing_yaml = TRUE)
 }
 \arguments{
 \item{dep_structure}{\code{dependency_structure} object}
+
+\item{skip_if_missing_yaml}{\code{logical} should checks be skipped on packages
+without yaml files. Default \code{TRUE}}
 }
 \value{
 NULL if successful. An error is thrown if inconsistencies found

--- a/man/check_yamls_consistent.Rd
+++ b/man/check_yamls_consistent.Rd
@@ -5,13 +5,13 @@
 \title{Checks that the staged dependency yamls are consistent with
 the dependencies listed in the DESCRIPTION files}
 \usage{
-check_yamls_consistent(dep_structure, skip_if_missing_yaml = TRUE)
+check_yamls_consistent(dep_structure, skip_if_missing_yaml = FALSE)
 }
 \arguments{
 \item{dep_structure}{\code{dependency_structure} object}
 
 \item{skip_if_missing_yaml}{\code{logical} should checks be skipped on packages
-without yaml files. Default \code{TRUE}}
+without yaml files. Default \code{FALSE}}
 }
 \value{
 NULL if successful. An error is thrown if inconsistencies found


### PR DESCRIPTION
Required for #66 

We want to option to skip checks on a given repo if there is no yaml file (e.g. rtables) 

Once merged in and tagged PRs to use this can be merged in e.g. https://github.com/insightsengineering/utils.nest/pull/37

Then #66 can be closed
