### PR TITLE
Add header to distinguish sticky comments

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -128,6 +128,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
         with:
+          header: R CMD check for R v${{ matrix.config.tag }}
           message: |
             #### R CMD check for R v${{ matrix.config.tag }}
 
@@ -190,6 +191,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ steps.check_junit_xml.outputs.files_exists == 'true' && github.event_name == 'pull_request' }}
         with:
+          header: Unit Test Details
           message: |
             ## Unit Test Details
 


### PR DESCRIPTION
Header to determine if the comment should be updated (it is not shown to users). It can be used when you want to add multiple comments independently to a given object.