### PR TITLE
more gracefully handle missing visNetwork

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -171,7 +171,7 @@ print.dependency_structure <- function(x, ...) {
 plot.dependency_structure <- function(x, y, ...){
 
   # construct visNetwork graph
-  require_pkgs(c("dplyr", "visNetwork"))
+  require_pkgs("visNetwork")
   # todo: put branch below node: https://github.com/almende/vis/issues/3436
   nodes <- x$table %>% dplyr::mutate(
     id = .data$package_name,

--- a/R/dependencies_app.R
+++ b/R/dependencies_app.R
@@ -23,6 +23,8 @@ install_deps_app <- function(project = ".", default_feature = NULL,
   require_pkgs(c("shiny", "miniUI", "visNetwork"))
 
   # take local version of project (rather than remote)
+  check_dir_exists(project)
+  error_if_stageddeps_inexistent(project)
   local_repos <- add_project_to_local_repos(project, local_repos)
 
   app <- shiny::shinyApp(

--- a/R/dependencies_app.R
+++ b/R/dependencies_app.R
@@ -20,7 +20,7 @@ install_deps_app <- function(project = ".", default_feature = NULL,
                              local_repos = get_local_pkgs_from_config(),
                              run_gadget = TRUE, run_as_job = TRUE,
                              verbose = 1, install_external_deps = TRUE, ...) {
-  require_pkgs(c("shiny", "miniUI"))
+  require_pkgs(c("shiny", "miniUI", "visNetwork"))
 
   # take local version of project (rather than remote)
   local_repos <- add_project_to_local_repos(project, local_repos)

--- a/R/utils.R
+++ b/R/utils.R
@@ -71,7 +71,7 @@ check_direction_arg <- function(direction) {
 require_pkgs <- function(pkgs) {
   for (pkg in pkgs) {
     if (!requireNamespace(pkg, quietly = TRUE)) {
-      stop("Please install R package ", pkg)
+      stop("For this feature of staged.dependencies, please install R package ", pkg)
     }
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -71,7 +71,7 @@ check_direction_arg <- function(direction) {
 require_pkgs <- function(pkgs) {
   for (pkg in pkgs) {
     if (!requireNamespace(pkg, quietly = TRUE)) {
-      stop("Please install ", pkg)
+      stop("Please install R package ", pkg)
     }
   }
 }


### PR DESCRIPTION
Closes #79

So I'd rather leave visNetwork as a suggests as we don't need to install visNetwork for the bulk of the features of staged.dependencies and we don't want to have to install it for every automation run - but now we have:

![image](https://user-images.githubusercontent.com/15201933/133998142-6dd189d0-2c48-495f-98a8-70b9840d51bd.png)

