### PR TITLE
use rstudio project directory for addins

### DIFF
--- a/R/rstudio_addins.R
+++ b/R/rstudio_addins.R
@@ -4,19 +4,19 @@ NULL
 # Helper functions for addins since the addin functions are invoked without arguments
 
 install_deps_app_addin <- function(...) {
-  install_deps_app(verbose = 1)
+  install_deps_app(verbose = 1, project = rstudioapi::getActiveProject())
 }
 
 check_downstream_addin <- function(...) {
-  check_downstream_job(check_args = Sys.getenv("RCMDCHECK_ARGS"))
+  check_downstream_job(project = rstudioapi::getActiveProject(), check_args = Sys.getenv("RCMDCHECK_ARGS"))
 }
 
 test_downstream_addin <- function(...) {
-  check_downstream_job(only_tests = TRUE)
+  check_downstream_job(project = rstudioapi::getActiveProject(), only_tests = TRUE)
 }
 
 install_deps_addin <- function(...) {
-  install_deps_job(...)
+  install_deps_job(project = rstudioapi::getActiveProject(), ...)
 }
 
 upgrade_package_addin <- function(...) {


### PR DESCRIPTION
Closes #92

Test by opening an RStudio project, running `setwd("./R")` and then trying the addins.

Will require minor changes to https://github.com/openpharma/staged.dependencies/pull/110

Note - although rstudioapi is only in the suggests I think the jobs would never have worked before - so I don't think I need a `require("rstudioapi")` 