### PR TITLE
Revert description file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,3 +9,5 @@
 * Added a `NEWS.md` file to track changes to the package.
 
 ## Bugfixes
+
+* Fix bug when calling `check_downstream` after `install_deps` whereby incorrect error was shown saying sha has changed. 

--- a/R/git_tools.R
+++ b/R/git_tools.R
@@ -238,7 +238,7 @@ install_repo_add_sha <- function(repo_dir,
   # once we have installed or failed to install the package we reset the repo
   # so that further operations on the repo do not fail by the above
   # "the git directory contains changes" check
-  on.exit(git2r::reset(git2r::repository(repo_dir), reset_type = "hard", path = "HEAD"))
+  on.exit(git2r::reset(git2r::commits(".")[[1]], reset_type = "hard"))
 
   desc <- utils::modifyList(desc, metadata)
   write_dcf(source_desc, desc)

--- a/R/git_tools.R
+++ b/R/git_tools.R
@@ -238,7 +238,7 @@ install_repo_add_sha <- function(repo_dir,
   # once we have installed or failed to install the package we reset the repo
   # so that further operations on the repo do not fail by the above
   # "the git directory contains changes" check
-  on.exit(git2r::reset(repo_dir, reset_type = "hard", path = source_desc))
+  on.exit(git2r::reset(git2r::repository(repo_dir), reset_type = "hard", path = "HEAD"))
 
   desc <- utils::modifyList(desc, metadata)
   write_dcf(source_desc, desc)

--- a/R/git_tools.R
+++ b/R/git_tools.R
@@ -238,7 +238,7 @@ install_repo_add_sha <- function(repo_dir,
   # once we have installed or failed to install the package we reset the repo
   # so that further operations on the repo do not fail by the above
   # "the git directory contains changes" check
-  on.exit(git2r::reset(git2r::commits(".")[[1]], reset_type = "hard"))
+  on.exit(git2r::reset(git2r::commits(repo_dir)[[1]], reset_type = "hard"))
 
   desc <- utils::modifyList(desc, metadata)
   write_dcf(source_desc, desc)
@@ -250,7 +250,6 @@ install_repo_add_sha <- function(repo_dir,
   }
 
   utils::install.packages(repo_dir, repos = NULL, type = "source")
-
   invisible(NULL)
 }
 

--- a/R/git_tools.R
+++ b/R/git_tools.R
@@ -238,7 +238,7 @@ install_repo_add_sha <- function(repo_dir,
   # once we have installed or failed to install the package we reset the repo
   # so that further operations on the repo do not fail by the above
   # "the git directory contains changes" check
-  on.exit(git2r::reset(repo_dir, reset_type = "hard"))
+  on.exit(git2r::reset(repo_dir, reset_type = "hard", path = source_desc))
 
   desc <- utils::modifyList(desc, metadata)
   write_dcf(source_desc, desc)

--- a/R/git_tools.R
+++ b/R/git_tools.R
@@ -234,6 +234,12 @@ install_repo_add_sha <- function(repo_dir,
     #RemoteRef = x$ref,
     RemoteSha = commit_sha
   )
+
+  # once we have installed or failed to install the package we reset the repo
+  # so that further operations on the repo do not fail by the above
+  # "the git directory contains changes" check
+  on.exit(git2r::reset(repo_dir, reset_type = "hard"))
+
   desc <- utils::modifyList(desc, metadata)
   write_dcf(source_desc, desc)
 
@@ -244,8 +250,6 @@ install_repo_add_sha <- function(repo_dir,
   }
 
   utils::install.packages(repo_dir, repos = NULL, type = "source")
-
-  # we do not clean up the DESCRIPTION file
 
   invisible(NULL)
 }


### PR DESCRIPTION
Closes #116

Test by running for example:

```
library(staged.dependencies)
x <- dependency_table(<<args>>)
install_deps(x)
install_deps(x)
``` 

Compare on main (2nd call to `install_deps` errors) and on this branch (works and says skipping installation).

Also test running install_deps followed by check_downstream or by killing the install_deps job partway through and restarting it

