### PR TITLE
Fallback to default branch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ Imports:
     digest,
     dplyr,
     fs,
-    gert,
     git2r,
     glue,
     httr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ Imports:
     digest,
     dplyr,
     fs,
+    gert,
     git2r,
     glue,
     httr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Other improvements
 
 * Added a `NEWS.md` file to track changes to the package.
+* Fallback branch for repositories is now the default branch of the repo, not hard-coded as `main`.
 
 ## Bugfixes
 

--- a/R/caching.R
+++ b/R/caching.R
@@ -109,7 +109,7 @@ copy_local_repo_to_cachedir <- function(local_dir, repo, host, select_ref_rule, 
   current_branch <- get_current_branch(repo_dir)
   if (!is.null(current_branch)) {
     available_refs <- available_references(repo_dir, branch_flag = "local")
-    ref <- select_ref_rule(available_refs, fallback_branch =  get_default_branch(repo_dir))
+    ref <- select_ref_rule(available_refs, fallback_branch = get_default_branch(repo_dir))
     stopifnot(ref %in% available_refs$ref)
 
     if (ref != get_current_branch(repo_dir)) {

--- a/R/caching.R
+++ b/R/caching.R
@@ -109,7 +109,7 @@ copy_local_repo_to_cachedir <- function(local_dir, repo, host, select_ref_rule, 
   current_branch <- get_current_branch(repo_dir)
   if (!is.null(current_branch)) {
     available_refs <- available_references(repo_dir, branch_flag = "local")
-    ref <- select_ref_rule(available_refs)
+    ref <- select_ref_rule(available_refs, fallback_branch =  get_default_branch(repo_dir))
     stopifnot(ref %in% available_refs$ref)
 
     if (ref != get_current_branch(repo_dir)) {
@@ -215,8 +215,8 @@ rec_checkout_internal_deps <- function(repos_to_process, ref,
     if (hashed_repo_and_host %in% names(local_repo_to_dir)) {
       repo_info <- copy_local_repo_to_cachedir(
         local_repo_to_dir[[hashed_repo_and_host]], repo_and_host$repo, repo_and_host$host,
-        select_ref_rule = function(available_refs) {
-          determine_ref(ref, available_refs)
+        select_ref_rule = function(available_refs, fallback_branch) {
+          determine_ref(ref, available_refs, fallback_branch = fallback_branch)
         },
         verbose = verbose
       )
@@ -225,8 +225,8 @@ rec_checkout_internal_deps <- function(repos_to_process, ref,
         get_repo_cache_dir(repo_and_host$repo, repo_and_host$host),
         get_repo_url(repo_and_host$repo, repo_and_host$host),
         token_envvar = get_authtoken_envvar(repo_and_host$host),
-        select_ref_rule = function(available_refs) {
-          determine_ref(ref, available_refs)
+        select_ref_rule = function(available_refs, fallback_branch) {
+          determine_ref(ref, available_refs, fallback_branch = fallback_branch)
         },
         verbose = verbose
       )

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -81,7 +81,6 @@ dependency_table <- function(project = ".",
     if (is.null(ref) || nchar(ref) == 0) {
       ref <- infer_ref_from_branch(project)
     }
-    check_ref_consistency(ref, project)
   }
 
   if (project_type == "local") {
@@ -89,6 +88,7 @@ dependency_table <- function(project = ".",
     local_repos <- add_project_to_local_repos(project, local_repos)
     repo_deps_info <- get_yaml_deps_info(project)
     repo_to_process <- list(repo_deps_info$current_repo)
+    check_ref_consistency(ref, project, repo_to_process[[1]])
   } else {
     repo_to_process <- list(parse_remote_project(project))
   }

--- a/R/git_tools.R
+++ b/R/git_tools.R
@@ -122,7 +122,7 @@ checkout_repo <- function(repo_dir, repo_url, select_ref_rule, token_envvar = NU
   check_only_remote_branches(git_repo)
 
   available_refs <- available_references(repo_dir)
-  selected_ref <- select_ref_rule(available_refs, get_default_branch(repo_dir))
+  selected_ref <- select_ref_rule(available_refs, get_default_branch(repo_dir, credentials = creds))
 
   if (attr(selected_ref, "type") == "branch") {
     if (!selected_ref %in% available_refs$ref[available_refs$type == "branch"]) {
@@ -258,10 +258,11 @@ get_short_sha <- function(repo_dir) {
   substr(git2r::sha(git2r::repository_head(repo_dir)), 1, 7)
 }
 
-get_default_branch <- function(repo_dir) {
+get_default_branch <- function(repo_dir, credentials) {
   default_branch <- tryCatch({
-    x <- gert::git_remote_ls(remote = git2r::remotes()[1], repo = repo_dir)$symref
-    utils::tail(strsplit(x[!is.na(x)], split = "/")[[1]], 1)
+    x <- git2r::remote_ls(name = "origin", repo = git2r::repository(repo_dir), credentials = credentials)
+    y <- names(x[x == x[names(x) == "HEAD"]])
+    utils::tail(strsplit(y[y != "HEAD"], split = "/")[[1]], 1)
   }, error = function(e) "main")
   return(default_branch)
 }

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ This can be checked by setting `ref = fix1@feature1@main` and running `check_dow
 A PR on either `repoB` or `repoC` `feature1@main --> main` takes 
 `repoA: main, repoB:feature1@main, repoC: feature1@main`, setting `ref = feature1@main`.
 
-By setting `ref = <<tag_name>>`, `staged.dependencies` will checkout each repository at the tagged commit (or `main`)
-if tag does not exist. The check for tag name takes priority over the branch procedure described above.
+By setting `ref = <<tag_name>>`, `staged.dependencies` will checkout each repository at the tagged commit (or git reference
+branch - typically `main`) if tag does not exist. The check for tag name takes priority over the branch procedure described above.
 
 ### Working with local packages
 

--- a/man/determine_ref.Rd
+++ b/man/determine_ref.Rd
@@ -4,7 +4,7 @@
 \alias{determine_ref}
 \title{Determine the branch/tag to install based on feature (staging rules)}
 \usage{
-determine_ref(ref, available_refs, branch_sep = "@")
+determine_ref(ref, available_refs, branch_sep = "@", fallback_branch = "main")
 }
 \arguments{
 \item{ref}{ref we want to build}
@@ -14,6 +14,8 @@ and \code{type} (\code{branch} or \code{tag})}
 
 \item{branch_sep}{separator between branches in \code{feature}, \code{/} does not
 work well with \code{git} because it clashes with the filesystem paths}
+
+\item{fallback_branch}{the default branch to try to use if no other matches found}
 }
 \value{
 branch/tag to choose to match feature, error if no suitable branch was provided

--- a/man/determine_ref.Rd
+++ b/man/determine_ref.Rd
@@ -4,7 +4,7 @@
 \alias{determine_ref}
 \title{Determine the branch/tag to install based on feature (staging rules)}
 \usage{
-determine_ref(ref, available_refs, branch_sep = "@", fallback_branch = "main")
+determine_ref(ref, available_refs, fallback_branch = "main", branch_sep = "@")
 }
 \arguments{
 \item{ref}{ref we want to build}
@@ -12,10 +12,10 @@ determine_ref(ref, available_refs, branch_sep = "@", fallback_branch = "main")
 \item{available_refs}{data.frame with columns \code{ref} the names of the available refs
 and \code{type} (\code{branch} or \code{tag})}
 
+\item{fallback_branch}{the default branch to try to use if no other matches found}
+
 \item{branch_sep}{separator between branches in \code{feature}, \code{/} does not
 work well with \code{git} because it clashes with the filesystem paths}
-
-\item{fallback_branch}{the default branch to try to use if no other matches found}
 }
 \value{
 branch/tag to choose to match feature, error if no suitable branch was provided

--- a/tests/testthat/test-caching.R
+++ b/tests/testthat/test-caching.R
@@ -47,7 +47,7 @@ test_that("rec_checkout_internal_deps works (with mocking checkout)", {
     fs::dir_copy(file.path(TESTS_GIT_REPOS, repo_name), repo_dir)
 
     available_refs <- available_references(repo_dir)
-    selected_ref <- select_ref_rule(available_refs)
+    selected_ref <- select_ref_rule(available_refs, fallback_branch = "main")
     # do not do actual checkout of branch
 
     return(list(dir = repo_dir, ref = selected_ref))
@@ -169,7 +169,8 @@ test_that("copy_local_repo_to_cachedir works", {
       copy_local_repo_to_cachedir(
         repo_dir,
         repo = "openpharma/stageddeps.food", host = "https://github.com",
-        select_ref_rule = function(available_refs) {
+        token_envvar = NULL,
+        select_ref_rule = function(available_refs, fallback_branch) {
           structure("main", type = "branch")
         },
         verbose = 2

--- a/tests/testthat/test-dependencies.R
+++ b/tests/testthat/test-dependencies.R
@@ -86,7 +86,6 @@ test_that("dependency_table wih local_pkgs works", {
     git2r::config(git2r::repository(repo_dir), user.name = "github.action", user.email = "gh@action.com")
   })
 
-
   local_pkgs <- c("stageddeps.elecinfra", "stageddeps.electricity", "stageddeps.food", "stageddeps.house", "stageddeps.garden", "stageddeps.water")
   local_repos <- data.frame(
     repo = paste0("openpharma/", local_pkgs),
@@ -94,6 +93,10 @@ test_that("dependency_table wih local_pkgs works", {
     directory = file.path(copied_ecosystem, local_pkgs),
     stringsAsFactors = FALSE
   )
+
+  mockery::stub(dependency_table, "get_default_branch", depth = 3, function(project, creds) {
+    return("main")
+  })
 
   # stageddeps.garden has branch fixgarden@main, so it should check it out
   expect_error(

--- a/tests/testthat/test-ref_strategy.R
+++ b/tests/testthat/test-ref_strategy.R
@@ -19,7 +19,12 @@ test_that("infer_ref_from_branch works", {
   unlink(repo_dir, recursive = TRUE)
 })
 
-test_that("check_ref_consistency works" , {
+test_that("check_ref_consistency works", {
+
+  mockery::stub(check_ref_consistency, "get_default_branch", function(project, creds) {
+    return("main")
+  })
+
 
   repo_dir <- tempfile("stageddeps.food")
   fs::dir_copy(file.path(TESTS_GIT_REPOS, "stageddeps.food"), repo_dir)
@@ -27,21 +32,21 @@ test_that("check_ref_consistency works" , {
 
   # ref fix1@main matches existing branch fix1@main better than main, so a warning
   expect_warning(
-    check_ref_consistency("fix1@main", repo_dir),
+    check_ref_consistency("fix1@main", repo_dir, list(repo = "openpharma/stageddeps.food", host = "https://github.com")),
     regexp = "Branch fix1@main would match fix1@main", fixed = TRUE
   )
 
   # checked out branch "main" is consistent with feature "superfix@main",
   # it still returns the feature "superfix@main" since it was provided
   expect_silent(
-    check_ref_consistency("superfix@main", repo_dir)
+    check_ref_consistency("superfix@main", repo_dir, list(repo = "openpharma/stageddeps.food", host = "https://github.com"))
   )
 
   git2r::checkout(repo_dir, "fix1@main")
 
   # checked out branch fix1@main is not consistent with provided branch superfix@main
   expect_warning(
-    check_ref_consistency("superfix@main", repo_dir),
+    check_ref_consistency("superfix@main", repo_dir, list(repo = "openpharma/stageddeps.food", host = "https://github.com")),
     refexp = "fix1@main", fixed = TRUE
   )
 

--- a/tests/testthat/test-ref_strategy.R
+++ b/tests/testthat/test-ref_strategy.R
@@ -139,5 +139,24 @@ test_that("determine_ref works", {
     determine_ref("feature1@release", data.frame(ref = c("master", "devel"), type = "branch")),
     regexp = "at least one of 'feature1@release, release, main'", fixed = TRUE
   )
+
+  # fallback "maaster" branch is an available branch, so use
+  expect_equal(
+    determine_ref("feature1@release", data.frame(ref = c("master", "devel"), type = "branch"), fallback_branch = "master"),
+    structure("master", type = "branch")
+  )
+
+  # different branch separator
+  expect_equal(
+    determine_ref(
+      "fix1#feature1#devel",
+      data.frame(ref = c("main", "devel", "feature1", "feature1#devel",
+                         "fix1@feature1@devel", "fix1"),
+                 type = "branch"),
+      branch_sep = "#"
+    ),
+    structure("feature1#devel", type = "branch")
+  )
+
 })
 


### PR DESCRIPTION
Closes #106 

Not completely sure the `default_branch` function is correct and not sure how to test this easily - thoughts?

I don't  like this PR as to get the default branch you need to talk to remote which breaks a lot of nice structure in the code (e.g. for local repos and for current project)

Will be nicer when we move to graphQL (though will need to pass in the fallback branch for the current project I think)