### PR TITLE
allow check_downstream to continue checking packages after errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Other improvements
 
 * Added a `NEWS.md` file to track changes to the package.
+* `check_downstream` will not stop on first package error but will run on all expected packages and all failures are output. 
 
 ## Bugfixes
 


### PR DESCRIPTION
Closes #137 

check_downstream now checks all packages even if some produce errors and the summary of all packages is output at the bottom - for example:

![image](https://user-images.githubusercontent.com/15201933/139828711-1994def0-0835-4721-8b23-fa51aa1b842d.png)
