### PR TITLE
Add renv lockfiles into object and use renv::install for external deps if inside renv environment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Suggests:
     knitr,
     miniUI,
     mockery,
+    renv,
     rmarkdown,
     rstudioapi,
     shiny,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Imports:
     git2r,
     glue,
     httr,
+    jsonlite,
     methods,
     rcmdcheck,
     remotes,
@@ -52,6 +53,7 @@ Collate:
     'graph_methods.R'
     'host.R'
     'ref_strategy.R'
+    'renv.R'
     'rstudio_jobs.R'
     'rstudio_addins.R'
     'utils.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Description: When developing multiple dependent packages, it is often useful to 
 License: file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
+Roxygen: list(markdown = TRUE)
 Suggests: 
     knitr,
     miniUI,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: staged.dependencies
 Type: Package
 Title: Install R packages from Particular Git Branches
-Version: 0.2.4
+Version: 0.2.5
 Authors@R: c(
   person("Adrian", "Waddell", email = "adrian.waddell@roche.com", role = c("aut", "cre")),
   person("Maximilian", "Mordig", email = "maximilian_oliver.mordig@roche.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# staged.dependencies 0.2.5 (unreleased)
+# staged.dependencies 0.2.5 
 
 * Added `renv_files` element into `dependency_structure` object to capture (in JSON) the renv.lock files from internal dependencies for future processing. The `renv_profile` argument to `dependency_table` allows you to choose which renv profile to include if not using the default one.
 * Use `renv::install` to install external dependencies if inside an `renv` environment so that the renv cache is used

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # staged.dependencies 0.2.5 (unreleased)
 
-* Added `renv_files` element into `dependency_structure` object to capture (in JSON) the renv.lock files from internal dependencies for future processing. The `renv_profile` argument to `dependency_table` allows you to choose which renv profile to include if not using the default one.  
+* Added `renv_files` element into `dependency_structure` object to capture (in JSON) the renv.lock files from internal dependencies for future processing. The `renv_profile` argument to `dependency_table` allows you to choose which renv profile to include if not using the default one.
+* Use `renv::install` to install external dependencies if inside an `renv` environment so that the renv cache is used
 
 # staged.dependencies 0.2.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # staged.dependencies 0.2.5 (unreleased)
 
+* Added `renv_files` element into `dependency_structure` object to capture (in JSON) the renv.lock files from internal dependencies for future processing. The `renv_profile` argument to `dependency_table` allows you to choose which renv profile to include if not using the default one.  
+
 # staged.dependencies 0.2.4
 
 ## Bugfixes

--- a/R/caching.R
+++ b/R/caching.R
@@ -101,10 +101,10 @@ copy_local_repo_to_cachedir <- function(local_dir, repo, host, select_ref_rule, 
     } else {
       # we need to copy lock files for different profiles which are stored
       # within the renv folder
-      renv_directory <- directory_to_copy
+      renv_directory <- dir
       renv_sub_directories <- fs::dir_ls(renv_directory, type = "directory", all = TRUE)
       if ("profiles" %in% fs::path_file(renv_sub_directories)) {
-        renv_profiles <- fs::dir_ls(fs::path_join(c(renv_sub_directories, "profiles")),
+        renv_profiles <- fs::dir_ls(fs::path_join(c(renv_directory, "profiles")),
                                     type = "directory", all = TRUE)
         lapply(renv_profiles, function(x) {
           fs::dir_create(fs::path_join(c(repo_dir, "renv", "profiles", fs::path_file(x))), recurse = TRUE)

--- a/R/caching.R
+++ b/R/caching.R
@@ -96,8 +96,26 @@ copy_local_repo_to_cachedir <- function(local_dir, repo, host, select_ref_rule, 
 
   lapply(fs::dir_ls(local_dir, type = "directory", all = TRUE), function(dir) {
     directory_to_copy <- utils::tail(strsplit(dir, .Platform$file.sep)[[1]], 1)
-    if(directory_to_copy != "renv") {
+    if (directory_to_copy != "renv") {
       fs::dir_copy(dir, repo_dir)
+    } else {
+      # we need to copy lock files for different profiles which are stored
+      # within the renv folder
+      renv_directory <- directory_to_copy
+      renv_sub_directories <- fs::dir_ls(renv_directory, type = "directory", all = TRUE)
+      if ("profiles" %in% fs::path_file(renv_sub_directories)) {
+        renv_profiles <- fs::dir_ls(fs::path_join(c(renv_sub_directories, "profiles")),
+                                    type = "directory", all = TRUE)
+        lapply(renv_profiles, function(x) {
+          fs::dir_create(fs::path_join(c(repo_dir, "renv", "profiles", fs::path_file(x))), recurse = TRUE)
+          if (fs::file_exists(fs::path_join(c(x, "renv.lock")))) {
+            fs::file_copy(
+              path = fs::path_join(c(x, "renv.lock")),
+              new_path = fs::path_join(c(repo_dir, "renv", "profiles", fs::path_file(x), "renv.lock"))
+            )
+          }
+        })
+      }
     }
   })
 

--- a/R/caching.R
+++ b/R/caching.R
@@ -99,23 +99,7 @@ copy_local_repo_to_cachedir <- function(local_dir, repo, host, select_ref_rule, 
     if (directory_to_copy != "renv") {
       fs::dir_copy(dir, repo_dir)
     } else {
-      # we need to copy lock files for different profiles which are stored
-      # within the renv folder
-      renv_directory <- dir
-      renv_sub_directories <- fs::dir_ls(renv_directory, type = "directory", all = TRUE)
-      if ("profiles" %in% fs::path_file(renv_sub_directories)) {
-        renv_profiles <- fs::dir_ls(fs::path_join(c(renv_directory, "profiles")),
-                                    type = "directory", all = TRUE)
-        lapply(renv_profiles, function(x) {
-          fs::dir_create(fs::path_join(c(repo_dir, "renv", "profiles", fs::path_file(x))), recurse = TRUE)
-          if (fs::file_exists(fs::path_join(c(x, "renv.lock")))) {
-            fs::file_copy(
-              path = fs::path_join(c(x, "renv.lock")),
-              new_path = fs::path_join(c(repo_dir, "renv", "profiles", fs::path_file(x), "renv.lock"))
-            )
-          }
-        })
-      }
+      copy_renv_profiles(dir, repo_dir)
     }
   })
 
@@ -165,6 +149,26 @@ copy_local_repo_to_cachedir <- function(local_dir, repo, host, select_ref_rule, 
 
   return(list(dir = repo_dir, ref = paste0("local (", current_branch, ")"),
               sha = get_short_sha(repo_dir), accessible = TRUE))
+}
+
+
+# we need to copy lock files for different profiles which are stored
+# within the renv folder but not copy all the libraries
+copy_renv_profiles <- function(renv_directory, repo_dir) {
+  renv_sub_directories <- fs::dir_ls(renv_directory, type = "directory", all = TRUE)
+  if ("profiles" %in% fs::path_file(renv_sub_directories)) {
+    renv_profiles <- fs::dir_ls(fs::path_join(c(renv_directory, "profiles")),
+                                type = "directory", all = TRUE)
+    lapply(renv_profiles, function(x) {
+      fs::dir_create(fs::path_join(c(repo_dir, "renv", "profiles", fs::path_file(x))), recurse = TRUE)
+      if (fs::file_exists(fs::path_join(c(x, "renv.lock")))) {
+        fs::file_copy(
+          path = fs::path_join(c(x, "renv.lock")),
+          new_path = fs::path_join(c(repo_dir, "renv", "profiles", fs::path_file(x), "renv.lock"))
+        )
+      }
+    })
+  }
 }
 
 # local_repos: data.frame that maps repo and host to local directory

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -326,7 +326,7 @@ plot.dependency_structure <- function(x, y, ...){
 #' @param install_direction "upstream", "downstream" or "all"; which packages
 #'   to install (according to dependency structure). By default this is only "upstream"
 #' @param install_external_deps logical to describe whether to install
-#'   external dependencies of package using `remotes::install_deps` (or `renv::install` if
+#'   external dependencies of package using [remotes::install_deps()] (or [renv::install()] if
 #'   inside an renv environment) .
 #' @param upgrade argument passed to `remotes::install_deps`, defaults to 'never'. Ignored
 #'   if inside an `renv` environment.

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -24,7 +24,7 @@
 #' @param fallback_branch (`character`) the default branch to try to use if
 #'   no other matches found
 #' @param renv_profile (`character`) the name of the renv profile of the `renv.lock` files
-#'   to be included from the repos. The standard renv.lock file uses the default NULL argument here.
+#'   to be included from the repos. The standard `renv.lock` file uses the default `NULL` argument here.
 #' @param verbose (`numeric`) verbosity level, incremental;
 #'   (0: None, 1: packages that get installed + high-level git operations,
 #'   2: includes git checkout infos)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -326,14 +326,17 @@ plot.dependency_structure <- function(x, y, ...){
 #' @param install_direction "upstream", "downstream" or "all"; which packages
 #'   to install (according to dependency structure). By default this is only "upstream"
 #' @param install_external_deps logical to describe whether to install
-#'   external dependencies of packages using `remotes::install_deps`.
-#' @param upgrade argument passed to `remotes::install_deps`, defaults to 'never'.
+#'   external dependencies of package using `remotes::install_deps` (or `renv::install` if
+#'   inside an renv environment) .
+#' @param upgrade argument passed to `remotes::install_deps`, defaults to 'never'. Ignored
+#'   if inside an `renv` environment.
 #' @param package_list (`character`) If not NULL, an additional filter, only packages on this
 #'   list will be considered and their dependencies installed if needed (advanced usage only).
 #' @param dry (`logical`) dry run that outputs what would happen without actually
 #'   doing it.
 #' @param verbose verbosity level, incremental; from 0 (none) to 2 (high)
-#' @param ... Additional args passed to `remotes::install_deps.
+#' @param ... Additional args passed to `remotes::install_deps. Ignored
+#'   if inside an `renv` environment.
 #'
 #' @return `data.frame` of performed actions
 #'

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -335,7 +335,7 @@ plot.dependency_structure <- function(x, y, ...){
 #' @param dry (`logical`) dry run that outputs what would happen without actually
 #'   doing it.
 #' @param verbose verbosity level, incremental; from 0 (none) to 2 (high)
-#' @param ... Additional args passed to `remotes::install_deps. Ignored
+#' @param ... Additional args passed to [remotes::install_deps()]. Ignored
 #'   if inside an `renv` environment.
 #'
 #' @return `data.frame` of performed actions

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -179,7 +179,7 @@ dependency_table <- function(project = ".",
                                         function(y) which(names(deps[["upstream_deps"]]) == y),
                                         FUN.VALUE = numeric(1))
 
-  renv_files <- lapply(internal_deps$cache_dir, get_renv_lock_from_repo_dir)
+  renv_files <- lapply(internal_deps$cache_dir, get_renv_lock_from_repo_dir, renv_profile = renv_profile)
   names(renv_files) <- internal_deps$package_name
 
   structure(

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -328,7 +328,7 @@ plot.dependency_structure <- function(x, y, ...){
 #' @param install_external_deps logical to describe whether to install
 #'   external dependencies of package using [remotes::install_deps()] (or [renv::install()] if
 #'   inside an renv environment) .
-#' @param upgrade argument passed to `remotes::install_deps`, defaults to 'never'. Ignored
+#' @param upgrade argument passed to [remotes::install_deps()], defaults to `'never'`. Ignored
 #'   if inside an `renv` environment.
 #' @param package_list (`character`) If not NULL, an additional filter, only packages on this
 #'   list will be considered and their dependencies installed if needed (advanced usage only).

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -23,6 +23,8 @@
 #'   either "upstream","downstream" or "all".
 #' @param fallback_branch (`character`) the default branch to try to use if
 #'   no other matches found
+#' @param renv_profile (`character`) the name of the renv profile of the renv.lock files
+#'   to be included from the repos. The standard renv.lock file uses the default NULL argument here.
 #' @param verbose (`numeric`) verbosity level, incremental;
 #'   (0: None, 1: packages that get installed + high-level git operations,
 #'   2: includes git checkout infos)
@@ -44,6 +46,8 @@
 #'               R packages found in the description files of the internal packages. It is a dataframe
 #'               of the form returned by `desc::desc_get_deps`}
 #'   \item{direction}{`direction` argument used to create object}
+#'   \item{renv_files}{`named list` containing the json of the renv.lock files for the chosen profile for
+#'                     each repo. An entry to the list is NULL if a repos does not have the required lock file}
 #' }
 #' @md
 #' @export
@@ -64,6 +68,7 @@ dependency_table <- function(project = ".",
                              local_repos = if ((project_type) == "local") get_local_pkgs_from_config() else NULL,
                              direction = "all",
                              fallback_branch = "main",
+                             renv_profile = NULL,
                              verbose = 1) {
 
   # validate arguments
@@ -129,7 +134,6 @@ dependency_table <- function(project = ".",
   # deps is ordered topologically
   deps <- get_true_deps_graph(internal_deps, graph_directions = "all")
 
-
   current_pkg <- internal_deps$package_name[
     internal_deps$repo == repo_to_process[[1]]$repo &
       internal_deps$host == repo_to_process[[1]]$host
@@ -174,6 +178,10 @@ dependency_table <- function(project = ".",
   internal_deps$install_index <- vapply(internal_deps$package_name,
                                         function(y) which(names(deps[["upstream_deps"]]) == y),
                                         FUN.VALUE = numeric(1))
+
+  renv_files <- lapply(internal_deps$cache_dir, get_renv_lock_from_repo_dir)
+  names(renv_files) <- internal_deps$package_name
+
   structure(
     list(
       project = if (project_type == "local") fs::path_abs(project) else project,
@@ -181,7 +189,8 @@ dependency_table <- function(project = ".",
       current_pkg = current_pkg,
       table = internal_deps,
       deps = deps,
-      direction = direction
+      direction = direction,
+      renv_files = renv_files
     ),
     class = "dependency_structure"
   )

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -23,7 +23,7 @@
 #'   either "upstream","downstream" or "all".
 #' @param fallback_branch (`character`) the default branch to try to use if
 #'   no other matches found
-#' @param renv_profile (`character`) the name of the renv profile of the renv.lock files
+#' @param renv_profile (`character`) the name of the renv profile of the `renv.lock` files
 #'   to be included from the repos. The standard renv.lock file uses the default NULL argument here.
 #' @param verbose (`numeric`) verbosity level, incremental;
 #'   (0: None, 1: packages that get installed + high-level git operations,

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -47,7 +47,7 @@
 #'               of the form returned by `desc::desc_get_deps`}
 #'   \item{direction}{`direction` argument used to create object}
 #'   \item{renv_files}{`named list` containing the json of the renv.lock files for the chosen profile for
-#'                     each repo. An entry to the list is NULL if a repos does not have the required lock file}
+#'                     each repo. An entry to the list is `NULL` if a repos does not have the required lock file}
 #' }
 #' @md
 #' @export

--- a/R/dependencies_app.R
+++ b/R/dependencies_app.R
@@ -14,6 +14,8 @@
 #' @param default_ref (`character`) default ref (branch/tag), see also the parameter
 #'   `ref` of `\link{dependency_table}`. If `NULL` this must be entered by app user
 #'   and can always be changed by the user.
+#' @param renv_profile (`character`) the name of the renv profile of the renv.lock files
+#'   to be included from the repos. The standard renv.lock file uses the default NULL argument here.
 #' @param fallback_branch (`character`) the default branch to try to use if
 #'   no other matches found
 #' @param run_gadget (`logical`) whether to run the app as a gadget
@@ -31,6 +33,7 @@ install_deps_app <- function(default_repo = NULL,
                              fallback_branch = "main",
                              run_gadget = TRUE, run_as_job = TRUE,
                              verbose = 1, install_external_deps = TRUE,
+                             renv_profile = NULL,
                              upgrade = "never", ...) {
   require_pkgs(c("shiny", "miniUI", "visNetwork"))
 
@@ -89,7 +92,7 @@ install_deps_app <- function(default_repo = NULL,
           }
           dependency_table(project = paste(input$repo, input$host, sep = "@"),
                            project_type = "repo@host", ref = input$ref, fallback_branch = fallback_branch,
-                           local_repos = NULL, verbose = 2)},
+                           local_repos = NULL, renv_profile = renv_profile, verbose = 2)},
           error = function(cond){
             error_rv(paste0("Cannot create dependency graph:\n", cond$message))
             NULL
@@ -151,7 +154,7 @@ install_deps_app <- function(default_repo = NULL,
             # this could be changed by using the importEnv argument
             # to jobRunScript and creating an install_deps job if dep_structure already exists in env
             install_deps_job(project = paste(input$repo, input$host, sep = "@"),  project_type = "repo@host", verbose = verbose,
-                             create_args = list(local_repos = NULL, ref = input$ref),
+                             create_args = list(local_repos = NULL, ref = input$ref, renv_profile = renv_profile),
                              dependency_packages = dependency_packages, fallback_branch = fallback_branch,
                              install_external_deps = install_external_deps,
                              install_direction = "all",

--- a/R/dependencies_app.R
+++ b/R/dependencies_app.R
@@ -14,7 +14,7 @@
 #' @param default_ref (`character`) default ref (branch/tag), see also the parameter
 #'   `ref` of `\link{dependency_table}`. If `NULL` this must be entered by app user
 #'   and can always be changed by the user.
-#' @param renv_profile (`character`) the name of the renv profile of the renv.lock files
+#' @param renv_profile (`character`) the name of the `renv` profile of the `renv.lock` files
 #'   to be included from the repos. The standard renv.lock file uses the default NULL argument here.
 #' @param fallback_branch (`character`) the default branch to try to use if
 #'   no other matches found

--- a/R/dependencies_app.R
+++ b/R/dependencies_app.R
@@ -15,7 +15,7 @@
 #'   `ref` of `\link{dependency_table}`. If `NULL` this must be entered by app user
 #'   and can always be changed by the user.
 #' @param renv_profile (`character`) the name of the `renv` profile of the `renv.lock` files
-#'   to be included from the repos. The standard renv.lock file uses the default NULL argument here.
+#'   to be included from the repos. The standard `renv.lock` file uses the default `NULL` argument here.
 #' @param fallback_branch (`character`) the default branch to try to use if
 #'   no other matches found
 #' @param run_gadget (`logical`) whether to run the app as a gadget

--- a/R/dependencies_helper.R
+++ b/R/dependencies_helper.R
@@ -23,7 +23,7 @@
 #' @param artifact_dir directory to store log files, only when actions include
 #'   `build`; action `test` only outputs to the console
 #' @param verbose verbosity level, incremental - from 0 (none) to 2 (high)
-#' @param ... Additional args passed to `remotes::install_deps Ignored
+#' @param ... Additional args passed to [remotes::install_deps()] Ignored
 #'   if inside an `renv` environment.
 run_package_actions <- function(pkg_actions, internal_pkg_deps,
                                 dry = FALSE,

--- a/R/dependencies_helper.R
+++ b/R/dependencies_helper.R
@@ -13,9 +13,9 @@
 #' @param internal_pkg_deps packages to not install (when `install_external_deps = TRUE`)
 #' @param dry logical, if `FALSE` (default) run the actions, if `TRUE` do not
 #' @param install_external_deps logical to describe whether to install
-#'   external dependencies of package using `remotes::install_deps` (or `renv::install` if
-#'   inside an renv environment) .
-#' @param upgrade argument passed to `remotes::install_deps`, defaults to 'never'. Ignored
+#'   external dependencies of package using [remotes::install_deps()] (or [renv::install()] if
+#'   inside an `renv` environment) .
+#' @param upgrade argument passed to [remotes::install_deps()], defaults to `'never'`. Ignored
 #'   if inside an `renv` environment.
 #' @param rcmd_args list with names `build`, `check`,
 #'   `install` which are vectors that are passed as separate arguments

--- a/R/dependencies_helper.R
+++ b/R/dependencies_helper.R
@@ -13,15 +13,18 @@
 #' @param internal_pkg_deps packages to not install (when `install_external_deps = TRUE`)
 #' @param dry logical, if `FALSE` (default) run the actions, if `TRUE` do not
 #' @param install_external_deps logical to describe whether to install
-#'   external dependencies of package using `remotes::install_deps`.
-#' @param upgrade argument passed to `remotes::install_deps`, defaults to 'never'.
+#'   external dependencies of package using `remotes::install_deps` (or `renv::install` if
+#'   inside an renv environment) .
+#' @param upgrade argument passed to `remotes::install_deps`, defaults to 'never'. Ignored
+#'   if inside an `renv` environment.
 #' @param rcmd_args list with names `build`, `check`,
 #'   `install` which are vectors that are passed as separate arguments
 #'   to the `R CMD` commands
 #' @param artifact_dir directory to store log files, only when actions include
 #'   `build`; action `test` only outputs to the console
 #' @param verbose verbosity level, incremental - from 0 (none) to 2 (high)
-#' @param ... Additional args passed to `remotes::install_deps.
+#' @param ... Additional args passed to `remotes::install_deps Ignored
+#'   if inside an `renv` environment.
 run_package_actions <- function(pkg_actions, internal_pkg_deps,
                                 dry = FALSE,
                                 install_external_deps = TRUE,

--- a/R/git_tools.R
+++ b/R/git_tools.R
@@ -176,14 +176,11 @@ install_external_deps <- function(repo_dir, internal_pkg_deps, ...) {
   desc_obj <- desc::desc(file.path(repo_dir_external, "DESCRIPTION"))
   new_deps <- desc_obj$get_deps()[!desc_obj$get_deps()$package %in% internal_pkg_deps,]
 
-  #also change name to make it clearer for users when using renv::install
-  desc_obj$set(Package = "staged.deps.tmp.pkg")
   desc_obj$set_deps(new_deps)
   desc_obj$write()
 
   if (!is.null(Sys.getenv("RENV_PROJECT")) && Sys.getenv("RENV_PROJECT") != "" && requireNamespace("renv", quietly = TRUE)) {
     renv::install(repo_dir_external)
-    renv::remove("staged.deps.tmp.pkg")
   } else {
     remotes::install_deps(repo_dir_external, ...)
   }

--- a/R/git_tools.R
+++ b/R/git_tools.R
@@ -183,6 +183,7 @@ install_external_deps <- function(repo_dir, internal_pkg_deps, ...) {
 
   if (!is.null(Sys.getenv("RENV_PROJECT")) && Sys.getenv("RENV_PROJECT") != "" && requireNamespace("renv", quietly = TRUE)) {
     renv::install(repo_dir_external)
+    renv::remove("staged.deps.tmp.pkg")
   } else {
     remotes::install_deps(repo_dir_external, ...)
   }

--- a/R/git_tools.R
+++ b/R/git_tools.R
@@ -163,8 +163,9 @@ checkout_repo <- function(repo_dir, repo_url, select_ref_rule, token_envvar = NU
 # Install the external deps required for a package
 # does not install dependencies that appear in `internal_pkg_deps`
 install_external_deps <- function(repo_dir, internal_pkg_deps, ...) {
-  # `remotes::install_deps` only makes use of the package DESCRIPTION file via
-  # `remotes:::load_pkg_description`
+
+  # `remotes::install_deps` (and renv::install)
+  #  only makes use of the package DESCRIPTION file
   # So we create a temp directory containing this file and then call this function
   repo_dir_external <- tempfile(paste0(basename(repo_dir), "_externalDeps"))
   fs::dir_create(repo_dir_external)
@@ -174,10 +175,17 @@ install_external_deps <- function(repo_dir, internal_pkg_deps, ...) {
   # remove internal_pkg_deps from DESCRIPTION file
   desc_obj <- desc::desc(file.path(repo_dir_external, "DESCRIPTION"))
   new_deps <- desc_obj$get_deps()[!desc_obj$get_deps()$package %in% internal_pkg_deps,]
+
+  #also change name to make it clearer for users when using renv::install
+  desc_obj$set(Package = "staged.deps.tmp.pkg")
   desc_obj$set_deps(new_deps)
   desc_obj$write()
 
-  remotes::install_deps(repo_dir_external, ...)
+  if (!is.null(Sys.getenv("RENV_PROJECT")) && Sys.getenv("RENV_PROJECT") != "" && requireNamespace("renv", quietly = TRUE)) {
+    renv::install(repo_dir_external)
+  } else {
+    remotes::install_deps(repo_dir_external, ...)
+  }
 }
 
 

--- a/R/renv.R
+++ b/R/renv.R
@@ -1,0 +1,20 @@
+get_renv_lock_from_repo_dir <- function(repo_dir, renv_profile = NULL) {
+  if (!is.null(renv_profile)) {
+    renv_file <- fs::path_join(c(repo_dir, "renv", "profiles", renv_profile, "renv.lock"))
+  } else {
+    renv_file <- fs::path_join(c(repo_dir, "renv.lock"))
+  }
+
+
+  if (!fs::file_exists(renv_file)) {
+    return(NULL)
+  }
+
+  renv_lock <- tryCatch(
+    jsonlite::read_json(renv_file),
+    error = function(cond) {
+      warning(paste("Unable to open renv.lock file", renv_file, "so it will be ignored"))
+      NULL
+    })
+  return(renv_lock)
+}

--- a/R/rstudio_jobs.R
+++ b/R/rstudio_jobs.R
@@ -24,7 +24,8 @@ run_job <- function(text, tempfile_prefix = "file", jobname_prefix = "Job", ...)
 #' install_deps_job(create_args = list(direction = "all"))
 #' install_deps_job(dry_install = TRUE)
 #' }
-install_deps_job <- function(project = ".", project_type = "local", verbose = 1, create_args = list(), ...) {
+install_deps_job <- function(project = ".", project_type = "local", verbose = 1,
+                             create_args = list(renv_profile = Sys.getenv("RENV_PROFILE")), ...) {
   if (project_type == "local") {
     project <- normalize_path(project)
   }
@@ -58,7 +59,8 @@ install_deps_job <- function(project = ".", project_type = "local", verbose = 1,
 #'                      list(create_arg = list(ref = "6_makegraph@main")))
 #' check_downstream_job(only_tests = TRUE)
 #' }
-check_downstream_job <- function(project = ".", verbose = 1, create_args = list(), ...) {
+check_downstream_job <- function(project = ".", verbose = 1,
+                                 create_args = list(renv_profile = Sys.getenv("RENV_PROFILE")), ...) {
   project <- normalize_path(project)
   create_args <- c(list(project = project, verbose = verbose), create_args)
   create_args_str <- paste(deparse(create_args), collapse = "\n")

--- a/man/build_check_install.Rd
+++ b/man/build_check_install.Rd
@@ -39,9 +39,11 @@ to the \verb{R CMD} commands}
 and logs}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of packages using \code{remotes::install_deps}.}
+external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+inside an renv environment) .}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'.}
+\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+if inside an \code{renv} environment.}
 
 \item{package_list}{(\code{character}) If not NULL, an additional filter, only packages on this
 list will be considered and their dependencies installed if needed (advanced usage only).}

--- a/man/build_check_install.Rd
+++ b/man/build_check_install.Rd
@@ -39,10 +39,10 @@ to the \verb{R CMD} commands}
 and logs}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+external dependencies of package using \code{\link[remotes:install_deps]{remotes::install_deps()}} (or \code{\link[renv:install]{renv::install()}} if
 inside an renv environment) .}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+\item{upgrade}{argument passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}, defaults to \code{'never'}. Ignored
 if inside an \code{renv} environment.}
 
 \item{package_list}{(\code{character}) If not NULL, an additional filter, only packages on this

--- a/man/check_downstream.Rd
+++ b/man/check_downstream.Rd
@@ -32,10 +32,10 @@ packages at most this distance from the \code{dependency_structure$current_pkg}
 \item{only_tests}{(\code{logical}) whether to only run tests (rather than checks)}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+external dependencies of package using \code{\link[remotes:install_deps]{remotes::install_deps()}} (or \code{\link[renv:install]{renv::install()}} if
 inside an renv environment) .}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+\item{upgrade}{argument passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}, defaults to \code{'never'}. Ignored
 if inside an \code{renv} environment.}
 
 \item{package_list}{(\code{character}) If not NULL, an additional filter, only packages on this

--- a/man/check_downstream.Rd
+++ b/man/check_downstream.Rd
@@ -32,9 +32,11 @@ packages at most this distance from the \code{dependency_structure$current_pkg}
 \item{only_tests}{(\code{logical}) whether to only run tests (rather than checks)}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of packages using \code{remotes::install_deps}.}
+external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+inside an renv environment) .}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'.}
+\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+if inside an \code{renv} environment.}
 
 \item{package_list}{(\code{character}) If not NULL, an additional filter, only packages on this
 list will be considered and their dependencies installed if needed (advanced usage only).}

--- a/man/check_downstream_job.Rd
+++ b/man/check_downstream_job.Rd
@@ -23,7 +23,7 @@ is assumed.}
 (0: None, 1: packages that get installed + high-level git operations,
 2: includes git checkout infos)}
 
-\item{create_args}{\code{named list} - additional arguments passed to `dependency_table` function}
+\item{create_args}{\code{named list} - additional arguments passed to \code{dependency_table} function}
 
 \item{...}{
   Arguments passed on to \code{\link[=check_downstream]{check_downstream}}
@@ -38,9 +38,9 @@ packages at most this distance from the \code{dependency_structure$current_pkg}
 to apply action to and infer installation order;
 uses \code{dep_structure$deps} to infer upstream dependencies}
     \item{\code{install_external_deps}}{logical to describe whether to install
-external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+external dependencies of package using \code{\link[remotes:install_deps]{remotes::install_deps()}} (or \code{\link[renv:install]{renv::install()}} if
 inside an renv environment) .}
-    \item{\code{upgrade}}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+    \item{\code{upgrade}}{argument passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}, defaults to \code{'never'}. Ignored
 if inside an \code{renv} environment.}
     \item{\code{package_list}}{(\code{character}) If not NULL, an additional filter, only packages on this
 list will be considered and their dependencies installed if needed (advanced usage only).}

--- a/man/check_downstream_job.Rd
+++ b/man/check_downstream_job.Rd
@@ -4,7 +4,12 @@
 \alias{check_downstream_job}
 \title{Check & install downstream job}
 \usage{
-check_downstream_job(project = ".", verbose = 1, create_args = list(), ...)
+check_downstream_job(
+  project = ".",
+  verbose = 1,
+  create_args = list(renv_profile = Sys.getenv("RENV_PROFILE")),
+  ...
+)
 }
 \arguments{
 \item{project}{(\code{character}) If \code{project_type} is \code{local} then

--- a/man/check_downstream_job.Rd
+++ b/man/check_downstream_job.Rd
@@ -38,8 +38,10 @@ packages at most this distance from the \code{dependency_structure$current_pkg}
 to apply action to and infer installation order;
 uses \code{dep_structure$deps} to infer upstream dependencies}
     \item{\code{install_external_deps}}{logical to describe whether to install
-external dependencies of packages using \code{remotes::install_deps}.}
-    \item{\code{upgrade}}{argument passed to \code{remotes::install_deps}, defaults to 'never'.}
+external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+inside an renv environment) .}
+    \item{\code{upgrade}}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+if inside an \code{renv} environment.}
     \item{\code{package_list}}{(\code{character}) If not NULL, an additional filter, only packages on this
 list will be considered and their dependencies installed if needed (advanced usage only).}
     \item{\code{dry}}{(\code{logical}) dry run that outputs what would happen without actually

--- a/man/dependency_table.Rd
+++ b/man/dependency_table.Rd
@@ -39,8 +39,8 @@ either "upstream","downstream" or "all".}
 \item{fallback_branch}{(\code{character}) the default branch to try to use if
 no other matches found}
 
-\item{renv_profile}{(\code{character}) the name of the renv profile of the renv.lock files
-to be included from the repos. The standard renv.lock file uses the default NULL argument here.}
+\item{renv_profile}{(\code{character}) the name of the renv profile of the \code{renv.lock} files
+to be included from the repos. The standard \code{renv.lock} file uses the default \code{NULL} argument here.}
 
 \item{verbose}{(\code{numeric}) verbosity level, incremental;
 (0: None, 1: packages that get installed + high-level git operations,
@@ -66,7 +66,7 @@ R packages found in the description files of the internal packages. It is a data
 of the form returned by \code{desc::desc_get_deps}}
 \item{direction}{\code{direction} argument used to create object}
 \item{renv_files}{\verb{named list} containing the json of the renv.lock files for the chosen profile for
-each repo. An entry to the list is NULL if a repos does not have the required lock file}
+each repo. An entry to the list is \code{NULL} if a repos does not have the required lock file}
 }
 }
 \description{

--- a/man/dependency_table.Rd
+++ b/man/dependency_table.Rd
@@ -11,6 +11,7 @@ dependency_table(
   local_repos = if ((project_type) == "local") get_local_pkgs_from_config() else NULL,
   direction = "all",
   fallback_branch = "main",
+  renv_profile = NULL,
   verbose = 1
 )
 }
@@ -38,6 +39,9 @@ either "upstream","downstream" or "all".}
 \item{fallback_branch}{(\code{character}) the default branch to try to use if
 no other matches found}
 
+\item{renv_profile}{(\code{character}) the name of the renv profile of the renv.lock files
+to be included from the repos. The standard renv.lock file uses the default NULL argument here.}
+
 \item{verbose}{(\code{numeric}) verbosity level, incremental;
 (0: None, 1: packages that get installed + high-level git operations,
 2: includes git checkout infos)}
@@ -61,6 +65,8 @@ and is ordered in reverse installation order. \code{external} contains the exter
 R packages found in the description files of the internal packages. It is a dataframe
 of the form returned by \code{desc::desc_get_deps}}
 \item{direction}{\code{direction} argument used to create object}
+\item{renv_files}{\verb{named list} containing the json of the renv.lock files for the chosen profile for
+each repo. An entry to the list is NULL if a repos does not have the required lock file}
 }
 }
 \description{

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -31,10 +31,10 @@ deps automatically install all their upstream deps)}
 to install (according to dependency structure). By default this is only "upstream"}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+external dependencies of package using \code{\link[remotes:install_deps]{remotes::install_deps()}} (or \code{\link[renv:install]{renv::install()}} if
 inside an renv environment) .}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+\item{upgrade}{argument passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}, defaults to \code{'never'}. Ignored
 if inside an \code{renv} environment.}
 
 \item{package_list}{(\code{character}) If not NULL, an additional filter, only packages on this
@@ -45,7 +45,8 @@ doing it.}
 
 \item{verbose}{verbosity level, incremental; from 0 (none) to 2 (high)}
 
-\item{...}{Additional args passed to \verb{remotes::install_deps. Ignored if inside an }renv` environment.}
+\item{...}{Additional args passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}. Ignored
+if inside an \code{renv} environment.}
 }
 \value{
 \code{data.frame} of performed actions

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -31,9 +31,11 @@ deps automatically install all their upstream deps)}
 to install (according to dependency structure). By default this is only "upstream"}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of packages using \code{remotes::install_deps}.}
+external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+inside an renv environment) .}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'.}
+\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+if inside an \code{renv} environment.}
 
 \item{package_list}{(\code{character}) If not NULL, an additional filter, only packages on this
 list will be considered and their dependencies installed if needed (advanced usage only).}
@@ -43,7 +45,7 @@ doing it.}
 
 \item{verbose}{verbosity level, incremental; from 0 (none) to 2 (high)}
 
-\item{...}{Additional args passed to `remotes::install_deps.}
+\item{...}{Additional args passed to \verb{remotes::install_deps. Ignored if inside an }renv` environment.}
 }
 \value{
 \code{data.frame} of performed actions

--- a/man/install_deps_app.Rd
+++ b/man/install_deps_app.Rd
@@ -41,16 +41,17 @@ no other matches found}
 \item{verbose}{verbosity level, incremental; from 0 (none) to 2 (high)}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+external dependencies of package using \code{\link[remotes:install_deps]{remotes::install_deps()}} (or \code{\link[renv:install]{renv::install()}} if
 inside an renv environment) .}
 
-\item{renv_profile}{(\code{character}) the name of the renv profile of the renv.lock files
-to be included from the repos. The standard renv.lock file uses the default NULL argument here.}
+\item{renv_profile}{(\code{character}) the name of the \code{renv} profile of the \code{renv.lock} files
+to be included from the repos. The standard \code{renv.lock} file uses the default \code{NULL} argument here.}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+\item{upgrade}{argument passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}, defaults to \code{'never'}. Ignored
 if inside an \code{renv} environment.}
 
-\item{...}{Additional args passed to \verb{remotes::install_deps. Ignored if inside an }renv` environment.}
+\item{...}{Additional args passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}. Ignored
+if inside an \code{renv} environment.}
 }
 \value{
 \code{shiny.app} or value returned by app (executed as a gadget)

--- a/man/install_deps_app.Rd
+++ b/man/install_deps_app.Rd
@@ -41,14 +41,16 @@ no other matches found}
 \item{verbose}{verbosity level, incremental; from 0 (none) to 2 (high)}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of packages using \code{remotes::install_deps}.}
+external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+inside an renv environment) .}
 
 \item{renv_profile}{(\code{character}) the name of the renv profile of the renv.lock files
 to be included from the repos. The standard renv.lock file uses the default NULL argument here.}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'.}
+\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+if inside an \code{renv} environment.}
 
-\item{...}{Additional args passed to `remotes::install_deps.}
+\item{...}{Additional args passed to \verb{remotes::install_deps. Ignored if inside an }renv` environment.}
 }
 \value{
 \code{shiny.app} or value returned by app (executed as a gadget)

--- a/man/install_deps_app.Rd
+++ b/man/install_deps_app.Rd
@@ -13,6 +13,7 @@ install_deps_app(
   run_as_job = TRUE,
   verbose = 1,
   install_external_deps = TRUE,
+  renv_profile = NULL,
   upgrade = "never",
   ...
 )
@@ -41,6 +42,9 @@ no other matches found}
 
 \item{install_external_deps}{logical to describe whether to install
 external dependencies of packages using \code{remotes::install_deps}.}
+
+\item{renv_profile}{(\code{character}) the name of the renv profile of the renv.lock files
+to be included from the repos. The standard renv.lock file uses the default NULL argument here.}
 
 \item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'.}
 

--- a/man/install_deps_job.Rd
+++ b/man/install_deps_job.Rd
@@ -42,8 +42,10 @@ deps automatically install all their upstream deps)}
     \item{\code{install_direction}}{"upstream", "downstream" or "all"; which packages
 to install (according to dependency structure). By default this is only "upstream"}
     \item{\code{install_external_deps}}{logical to describe whether to install
-external dependencies of packages using \code{remotes::install_deps}.}
-    \item{\code{upgrade}}{argument passed to \code{remotes::install_deps}, defaults to 'never'.}
+external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+inside an renv environment) .}
+    \item{\code{upgrade}}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+if inside an \code{renv} environment.}
     \item{\code{package_list}}{(\code{character}) If not NULL, an additional filter, only packages on this
 list will be considered and their dependencies installed if needed (advanced usage only).}
     \item{\code{dry}}{(\code{logical}) dry run that outputs what would happen without actually

--- a/man/install_deps_job.Rd
+++ b/man/install_deps_job.Rd
@@ -8,7 +8,7 @@ install_deps_job(
   project = ".",
   project_type = "local",
   verbose = 1,
-  create_args = list(),
+  create_args = list(renv_profile = Sys.getenv("RENV_PROFILE")),
   ...
 )
 }

--- a/man/install_deps_job.Rd
+++ b/man/install_deps_job.Rd
@@ -26,7 +26,7 @@ is assumed.}
 (0: None, 1: packages that get installed + high-level git operations,
 2: includes git checkout infos)}
 
-\item{create_args}{\code{named list} - additional arguments passed to `dependency_table` function}
+\item{create_args}{\code{named list} - additional arguments passed to \code{dependency_table} function}
 
 \item{...}{
   Arguments passed on to \code{\link[=install_deps]{install_deps}}
@@ -42,9 +42,9 @@ deps automatically install all their upstream deps)}
     \item{\code{install_direction}}{"upstream", "downstream" or "all"; which packages
 to install (according to dependency structure). By default this is only "upstream"}
     \item{\code{install_external_deps}}{logical to describe whether to install
-external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+external dependencies of package using \code{\link[remotes:install_deps]{remotes::install_deps()}} (or \code{\link[renv:install]{renv::install()}} if
 inside an renv environment) .}
-    \item{\code{upgrade}}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+    \item{\code{upgrade}}{argument passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}, defaults to \code{'never'}. Ignored
 if inside an \code{renv} environment.}
     \item{\code{package_list}}{(\code{character}) If not NULL, an additional filter, only packages on this
 list will be considered and their dependencies installed if needed (advanced usage only).}

--- a/man/install_repo_add_sha.Rd
+++ b/man/install_repo_add_sha.Rd
@@ -9,7 +9,7 @@ install_repo_add_sha(repo_dir, ...)
 \arguments{
 \item{repo_dir}{directory of repo}
 
-\item{...}{Additional args passed to `remotes::install_deps`. Note `upgrade`
+\item{...}{Additional args passed to \code{remotes::install_deps}. Note \code{upgrade}
 is set to "never" and shouldn't be passed into this function.}
 }
 \description{

--- a/man/run_package_actions.Rd
+++ b/man/run_package_actions.Rd
@@ -34,9 +34,11 @@ otherwise \verb{R CMD INSTALL} on tarball
 \item{dry}{logical, if \code{FALSE} (default) run the actions, if \code{TRUE} do not}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of package using \code{remotes::install_deps}.}
+external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
+inside an renv environment) .}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'.}
+\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+if inside an \code{renv} environment.}
 
 \item{rcmd_args}{list with names \code{build}, \code{check},
 \code{install} which are vectors that are passed as separate arguments
@@ -47,7 +49,7 @@ to the \verb{R CMD} commands}
 
 \item{verbose}{verbosity level, incremental - from 0 (none) to 2 (high)}
 
-\item{...}{Additional args passed to `remotes::install_deps.}
+\item{...}{Additional args passed to \verb{remotes::install_deps Ignored if inside an }renv` environment.}
 }
 \description{
 Run an action on the packages

--- a/man/run_package_actions.Rd
+++ b/man/run_package_actions.Rd
@@ -34,10 +34,10 @@ otherwise \verb{R CMD INSTALL} on tarball
 \item{dry}{logical, if \code{FALSE} (default) run the actions, if \code{TRUE} do not}
 
 \item{install_external_deps}{logical to describe whether to install
-external dependencies of package using \code{remotes::install_deps} (or \code{renv::install} if
-inside an renv environment) .}
+external dependencies of package using \code{\link[remotes:install_deps]{remotes::install_deps()}} (or \code{\link[renv:install]{renv::install()}} if
+inside an \code{renv} environment) .}
 
-\item{upgrade}{argument passed to \code{remotes::install_deps}, defaults to 'never'. Ignored
+\item{upgrade}{argument passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}, defaults to \code{'never'}. Ignored
 if inside an \code{renv} environment.}
 
 \item{rcmd_args}{list with names \code{build}, \code{check},

--- a/man/run_package_actions.Rd
+++ b/man/run_package_actions.Rd
@@ -49,7 +49,8 @@ to the \verb{R CMD} commands}
 
 \item{verbose}{verbosity level, incremental - from 0 (none) to 2 (high)}
 
-\item{...}{Additional args passed to \verb{remotes::install_deps Ignored if inside an }renv` environment.}
+\item{...}{Additional args passed to \code{\link[remotes:install_deps]{remotes::install_deps()}} Ignored
+if inside an \code{renv} environment.}
 }
 \description{
 Run an action on the packages

--- a/man/topological_sort.Rd
+++ b/man/topological_sort.Rd
@@ -7,7 +7,7 @@
 topological_sort(graph)
 }
 \arguments{
-\item{graph}{(named `list`) list with node vector elements mapping from
+\item{graph}{(named \code{list}) list with node vector elements mapping from
 child to its parents (upstream dependencies)}
 }
 \value{

--- a/renv.lock
+++ b/renv.lock
@@ -14,707 +14,1176 @@
       "Version": "2.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "470851b6d5d0ac559e9d01bb352b4021"
+      "Hash": "470851b6d5d0ac559e9d01bb352b4021",
+      "Requirements": []
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.7",
+      "Version": "1.0.8.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "dab19adae4440ae55aa8a9d238b246bb"
+      "Hash": "32e79b908fda56ee57fe518a8d37b864",
+      "Requirements": []
     },
     "askpass": {
       "Package": "askpass",
       "Version": "1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e8a22846fff485f0be3770c2da758713"
+      "Hash": "e8a22846fff485f0be3770c2da758713",
+      "Requirements": [
+        "sys"
+      ]
     },
     "base64enc": {
       "Package": "base64enc",
       "Version": "0.1-3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "543776ae6848fde2f48ff3816d0628bc"
+      "Hash": "543776ae6848fde2f48ff3816d0628bc",
+      "Requirements": []
     },
     "brew": {
       "Package": "brew",
-      "Version": "1.0-6",
+      "Version": "1.0-7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "92a5f887f9ae3035ac7afde22ba73ee9"
+      "Hash": "38875ea52350ff4b4c03849fc69736c8",
+      "Requirements": []
     },
     "brio": {
       "Package": "brio",
-      "Version": "1.1.2",
+      "Version": "1.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2f01e16ff9571fe70381c7b9ae560dc4"
+      "Hash": "976cf154dfb043c012d87cddd8bca363",
+      "Requirements": []
     },
     "bslib": {
       "Package": "bslib",
       "Version": "0.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "56ae7e1987b340186a8a5a157c2ec358"
+      "Hash": "56ae7e1987b340186a8a5a157c2ec358",
+      "Requirements": [
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "rlang",
+        "sass"
+      ]
     },
     "cachem": {
       "Package": "cachem",
       "Version": "1.0.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "648c5b3d71e6a37e3043617489a0a0e9"
+      "Hash": "648c5b3d71e6a37e3043617489a0a0e9",
+      "Requirements": [
+        "fastmap",
+        "rlang"
+      ]
     },
     "callr": {
       "Package": "callr",
       "Version": "3.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "461aa75a11ce2400245190ef5d3995df"
+      "Hash": "461aa75a11ce2400245190ef5d3995df",
+      "Requirements": [
+        "R6",
+        "processx"
+      ]
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.0.1",
+      "Version": "3.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e3ae5d68dea0c55a12ea12a9fda02e61"
+      "Hash": "23abf173c2b783dcc43379ab9bba00ee",
+      "Requirements": [
+        "glue"
+      ]
     },
     "clipr": {
       "Package": "clipr",
-      "Version": "0.7.1",
+      "Version": "0.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ebaa97ac99cc2daf04e77eecc7b781d7"
+      "Hash": "3f038e5ac7f41d4ac41ce658c85e3042",
+      "Requirements": []
     },
     "commonmark": {
       "Package": "commonmark",
-      "Version": "1.7",
+      "Version": "1.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0f22be39ec1d141fd03683c06f3a6e67"
+      "Hash": "2ba81b120c1655ab696c935ef33ea716",
+      "Requirements": []
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.4.0",
+      "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "40ba3fd26c8f61d8d14d334bc7761df9"
+      "Hash": "fa53ce256cd280f468c080a58ea5ba8c",
+      "Requirements": []
     },
     "crayon": {
       "Package": "crayon",
-      "Version": "1.4.1",
+      "Version": "1.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e75525c55c70e5f4f78c9960a4b402e9"
+      "Hash": "8dc45fd8a1ee067a92b85ef274e66d6a",
+      "Requirements": []
     },
     "credentials": {
       "Package": "credentials",
-      "Version": "1.3.1",
+      "Version": "1.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "db9463f8f96444ac790bef2076048699"
+      "Hash": "93762d0a34d78e6a025efdbfb5c6bb41",
+      "Requirements": [
+        "askpass",
+        "curl",
+        "jsonlite",
+        "openssl",
+        "sys"
+      ]
     },
     "curl": {
       "Package": "curl",
       "Version": "4.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "022c42d49c28e95d69ca60446dbabf88"
+      "Hash": "022c42d49c28e95d69ca60446dbabf88",
+      "Requirements": []
     },
     "desc": {
       "Package": "desc",
-      "Version": "1.4.0",
+      "Version": "1.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "28763d08fadd0b733e3cee9dab4e12fe"
+      "Hash": "eebd27ee58fcc58714eedb7aa07d8ad1",
+      "Requirements": [
+        "R6",
+        "cli",
+        "rprojroot"
+      ]
     },
     "devtools": {
       "Package": "devtools",
-      "Version": "2.4.2",
+      "Version": "2.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "048d0b914d2cea61f440d35dd3cbddac"
+      "Hash": "fc35e13bb582e5fe6f63f3d647a4cbe5",
+      "Requirements": [
+        "callr",
+        "cli",
+        "desc",
+        "ellipsis",
+        "fs",
+        "httr",
+        "lifecycle",
+        "memoise",
+        "pkgbuild",
+        "pkgload",
+        "rcmdcheck",
+        "remotes",
+        "rlang",
+        "roxygen2",
+        "rstudioapi",
+        "rversions",
+        "sessioninfo",
+        "testthat",
+        "usethis",
+        "withr"
+      ]
     },
     "diffobj": {
       "Package": "diffobj",
       "Version": "0.3.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "bcaa8b95f8d7d01a5dedfd959ce88ab8"
+      "Hash": "bcaa8b95f8d7d01a5dedfd959ce88ab8",
+      "Requirements": [
+        "crayon"
+      ]
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.28",
+      "Version": "0.6.29",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "49b5c6e230bfec487b8917d5a0c77cca"
+      "Hash": "cf6b206a045a684728c3267ef7596190",
+      "Requirements": []
     },
     "downlit": {
       "Package": "downlit",
-      "Version": "0.2.1",
+      "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f24f1e44320a978c03050b8403a83793"
+      "Hash": "ba63dc9ab5a31f3209892437e40c5f60",
+      "Requirements": [
+        "brio",
+        "desc",
+        "digest",
+        "evaluate",
+        "fansi",
+        "memoise",
+        "rlang",
+        "vctrs",
+        "yaml"
+      ]
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.0.7",
+      "Version": "1.0.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "36f1ae62f026c8ba9f9b5c9a08c03297"
+      "Hash": "f0bda1627a7f5d3f9a0b5add931596ac",
+      "Requirements": [
+        "R6",
+        "generics",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "pillar",
+        "rlang",
+        "tibble",
+        "tidyselect",
+        "vctrs"
+      ]
     },
     "ellipsis": {
       "Package": "ellipsis",
       "Version": "0.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
+      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077",
+      "Requirements": [
+        "rlang"
+      ]
     },
     "evaluate": {
       "Package": "evaluate",
-      "Version": "0.14",
+      "Version": "0.15",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
+      "Hash": "699a7a93d08c962d9f8950b2d7a227f1",
+      "Requirements": []
     },
     "fansi": {
       "Package": "fansi",
-      "Version": "0.5.0",
+      "Version": "1.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d447b40982c576a72b779f0a3b3da227"
+      "Hash": "83a8afdbe71839506baa9f90eebad7ec",
+      "Requirements": []
     },
     "fastmap": {
       "Package": "fastmap",
       "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "77bd60a6157420d4ffa93b27cf6a58b8"
+      "Hash": "77bd60a6157420d4ffa93b27cf6a58b8",
+      "Requirements": []
     },
     "fontawesome": {
       "Package": "fontawesome",
       "Version": "0.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "55624ed409e46c5f358b2c060be87f67"
+      "Hash": "55624ed409e46c5f358b2c060be87f67",
+      "Requirements": [
+        "htmltools",
+        "rlang"
+      ]
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.5.0",
+      "Version": "1.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "44594a07a42e5f91fac9f93fda6d0109"
+      "Hash": "7c89603d81793f0d5486d91ab1fc6f1d",
+      "Requirements": []
     },
     "generics": {
       "Package": "generics",
-      "Version": "0.1.0",
+      "Version": "0.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4d243a9c10b00589889fe32314ffd902"
+      "Hash": "177475892cf4a55865868527654a7741",
+      "Requirements": []
     },
     "gert": {
       "Package": "gert",
-      "Version": "1.4.1",
+      "Version": "1.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8e54ffecc152da9e1e366ff1a4012bb1"
+      "Hash": "98c014c4c933f23ea5a0321a4d0b588b",
+      "Requirements": [
+        "askpass",
+        "credentials",
+        "openssl",
+        "rstudioapi",
+        "sys",
+        "zip"
+      ]
     },
     "gh": {
       "Package": "gh",
       "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "38c2580abbda249bd6afeec00d14f531"
+      "Hash": "38c2580abbda249bd6afeec00d14f531",
+      "Requirements": [
+        "cli",
+        "gitcreds",
+        "httr",
+        "ini",
+        "jsonlite"
+      ]
     },
     "git2r": {
       "Package": "git2r",
-      "Version": "0.28.0",
+      "Version": "0.30.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f64fd34026f6025de71a4354800e6d79"
+      "Hash": "e0c6a04a3e7b90e64213d09128f74f1b",
+      "Requirements": []
     },
     "gitcreds": {
       "Package": "gitcreds",
       "Version": "0.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f3aefccc1cc50de6338146b62f115de8"
+      "Hash": "f3aefccc1cc50de6338146b62f115de8",
+      "Requirements": []
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.4.2",
+      "Version": "1.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6efd734b14c6471cfe443345f3e35e29"
+      "Hash": "4f2596dfb05dac67b9dc558e5c6fba2e",
+      "Requirements": []
     },
     "highr": {
       "Package": "highr",
       "Version": "0.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8eb36c8125038e648e5d111c0d7b2ed4"
+      "Hash": "8eb36c8125038e648e5d111c0d7b2ed4",
+      "Requirements": [
+        "xfun"
+      ]
     },
     "htmltools": {
       "Package": "htmltools",
       "Version": "0.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "526c484233f42522278ab06fb185cb26"
+      "Hash": "526c484233f42522278ab06fb185cb26",
+      "Requirements": [
+        "base64enc",
+        "digest",
+        "fastmap",
+        "rlang"
+      ]
     },
     "htmlwidgets": {
       "Package": "htmlwidgets",
       "Version": "1.5.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "76147821cd3fcd8c4b04e1ef0498e7fb"
+      "Hash": "76147821cd3fcd8c4b04e1ef0498e7fb",
+      "Requirements": [
+        "htmltools",
+        "jsonlite",
+        "yaml"
+      ]
     },
     "httpuv": {
       "Package": "httpuv",
-      "Version": "1.6.3",
+      "Version": "1.6.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "65e865802fe6dd1bafef1dae5b80a844"
+      "Hash": "97fe71f0a4a1c9890e6c2128afa04bc0",
+      "Requirements": [
+        "R6",
+        "Rcpp",
+        "later",
+        "promises"
+      ]
     },
     "httr": {
       "Package": "httr",
-      "Version": "1.4.2",
+      "Version": "1.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a525aba14184fec243f9eaec62fbed43"
+      "Hash": "88d1b310583777edf01ccd1216fb0b2b",
+      "Requirements": [
+        "R6",
+        "curl",
+        "jsonlite",
+        "mime",
+        "openssl"
+      ]
     },
     "ini": {
       "Package": "ini",
       "Version": "0.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6154ec2223172bce8162d4153cda21f7"
+      "Hash": "6154ec2223172bce8162d4153cda21f7",
+      "Requirements": []
     },
     "jquerylib": {
       "Package": "jquerylib",
       "Version": "0.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5aab57a3bd297eee1c1d862735972182"
+      "Hash": "5aab57a3bd297eee1c1d862735972182",
+      "Requirements": [
+        "htmltools"
+      ]
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.7.2",
+      "Version": "1.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "98138e0994d41508c7a6b84a0600cfcb"
+      "Hash": "d07e729b27b372429d42d24d503613a0",
+      "Requirements": []
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.36",
+      "Version": "1.39",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "46344b93f8854714cdf476433a59ed10"
+      "Hash": "029ab7c4badd3cf8af69016b2ba27493",
+      "Requirements": [
+        "evaluate",
+        "highr",
+        "stringr",
+        "xfun",
+        "yaml"
+      ]
     },
     "later": {
       "Package": "later",
       "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "7e7b457d7766bc47f2a5f21cc2984f8e"
+      "Hash": "7e7b457d7766bc47f2a5f21cc2984f8e",
+      "Requirements": [
+        "Rcpp",
+        "rlang"
+      ]
     },
     "lifecycle": {
       "Package": "lifecycle",
       "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a6b6d352e3ed897373ab19d8395c98d0"
+      "Hash": "a6b6d352e3ed897373ab19d8395c98d0",
+      "Requirements": [
+        "glue",
+        "rlang"
+      ]
     },
     "magrittr": {
       "Package": "magrittr",
-      "Version": "2.0.1",
+      "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "41287f1ac7d28a92f0a286ed507928d3"
+      "Hash": "7ce2733a9826b3aeb1775d56fd305472",
+      "Requirements": []
     },
     "memoise": {
       "Package": "memoise",
-      "Version": "2.0.0",
+      "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a0bc51650201a56d00a4798523cc91b3"
+      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c",
+      "Requirements": [
+        "cachem",
+        "rlang"
+      ]
     },
     "mime": {
       "Package": "mime",
       "Version": "0.12",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
+      "Hash": "18e9c28c1d3ca1560ce30658b22ce104",
+      "Requirements": []
     },
     "miniUI": {
       "Package": "miniUI",
       "Version": "0.1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fec5f52652d60615fdb3957b3d74324a"
+      "Hash": "fec5f52652d60615fdb3957b3d74324a",
+      "Requirements": [
+        "htmltools",
+        "shiny"
+      ]
     },
     "mockery": {
       "Package": "mockery",
-      "Version": "0.4.2",
+      "Version": "0.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "313fa6504824ba5aab9308412135fb5f"
+      "Hash": "c28ce5f7c2293d76b91657f3fe30c50b",
+      "Requirements": [
+        "testthat"
+      ]
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "1.4.5",
+      "Version": "2.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5406fd37ef0bf9b88c8a4f264d6ec220"
+      "Hash": "cf4329aac12c2c44089974559c18e446",
+      "Requirements": [
+        "askpass"
+      ]
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.6.3",
+      "Version": "1.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3323bc1a0988d63b5c65771ba0d3935d"
+      "Hash": "51dfc97e1b7069e9f7e6f83f3589c22e",
+      "Requirements": [
+        "cli",
+        "crayon",
+        "ellipsis",
+        "fansi",
+        "glue",
+        "lifecycle",
+        "rlang",
+        "utf8",
+        "vctrs"
+      ]
     },
     "pkgbuild": {
       "Package": "pkgbuild",
-      "Version": "1.2.0",
+      "Version": "1.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "725fcc30222d4d11ec68efb8ff11a9af"
+      "Hash": "66d2adfed274daf81ccfe77d974c3b9b",
+      "Requirements": [
+        "R6",
+        "callr",
+        "cli",
+        "crayon",
+        "desc",
+        "prettyunits",
+        "rprojroot",
+        "withr"
+      ]
     },
     "pkgconfig": {
       "Package": "pkgconfig",
       "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "01f28d4278f15c76cddbea05899c5d6f"
+      "Hash": "01f28d4278f15c76cddbea05899c5d6f",
+      "Requirements": []
     },
     "pkgdown": {
       "Package": "pkgdown",
-      "Version": "1.6.1",
+      "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8896076540d9e9b556a2ec658c81f916"
+      "Hash": "ec3139021900fa27faae7a821b732bf8",
+      "Requirements": [
+        "bslib",
+        "callr",
+        "crayon",
+        "desc",
+        "digest",
+        "downlit",
+        "fs",
+        "httr",
+        "jsonlite",
+        "magrittr",
+        "memoise",
+        "purrr",
+        "ragg",
+        "rlang",
+        "rmarkdown",
+        "tibble",
+        "whisker",
+        "withr",
+        "xml2",
+        "yaml"
+      ]
     },
     "pkgload": {
       "Package": "pkgload",
-      "Version": "1.2.2",
+      "Version": "1.2.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "53139eedf68b98eecd5289664969c3f2"
+      "Hash": "7533cd805940821bf23eaf3c8d4c1735",
+      "Requirements": [
+        "cli",
+        "crayon",
+        "desc",
+        "rlang",
+        "rprojroot",
+        "rstudioapi",
+        "withr"
+      ]
     },
     "praise": {
       "Package": "praise",
       "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a555924add98c99d2f411e37e7d25e9f"
+      "Hash": "a555924add98c99d2f411e37e7d25e9f",
+      "Requirements": []
     },
     "prettyunits": {
       "Package": "prettyunits",
       "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "95ef9167b75dde9d2ccc3c7528393e7e"
+      "Hash": "95ef9167b75dde9d2ccc3c7528393e7e",
+      "Requirements": []
     },
     "processx": {
       "Package": "processx",
-      "Version": "3.5.2",
+      "Version": "3.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0cbca2bc4d16525d009c4dbba156b37c"
+      "Hash": "8bbae1a548d0d3fdf6647bdd9d35bf6d",
+      "Requirements": [
+        "R6",
+        "ps"
+      ]
     },
     "promises": {
       "Package": "promises",
       "Version": "1.2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4ab2c43adb4d4699cf3690acd378d75d"
+      "Hash": "4ab2c43adb4d4699cf3690acd378d75d",
+      "Requirements": [
+        "R6",
+        "Rcpp",
+        "later",
+        "magrittr",
+        "rlang"
+      ]
     },
     "ps": {
       "Package": "ps",
-      "Version": "1.6.0",
+      "Version": "1.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "32620e2001c1dce1af49c49dccbb9420"
+      "Hash": "eef74b13f32cae6bb0d495e53317c44c",
+      "Requirements": []
     },
     "purrr": {
       "Package": "purrr",
       "Version": "0.3.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "97def703420c8ab10d8f0e6c72101e02"
+      "Hash": "97def703420c8ab10d8f0e6c72101e02",
+      "Requirements": [
+        "magrittr",
+        "rlang"
+      ]
     },
     "ragg": {
       "Package": "ragg",
-      "Version": "1.1.3",
+      "Version": "1.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "663065eff8c6c08eaa9955c6f478ee7a"
+      "Hash": "14932bb6f2739c771ca4ceaba6b4248e",
+      "Requirements": [
+        "systemfonts",
+        "textshaping"
+      ]
     },
     "rappdirs": {
       "Package": "rappdirs",
       "Version": "0.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
+      "Hash": "5e3c5dc0b071b21fa128676560dbe94d",
+      "Requirements": []
     },
     "rcmdcheck": {
       "Package": "rcmdcheck",
       "Version": "1.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8f25ebe2ec38b1f2aef3b0d2ef76f6c4"
+      "Hash": "8f25ebe2ec38b1f2aef3b0d2ef76f6c4",
+      "Requirements": [
+        "R6",
+        "callr",
+        "cli",
+        "curl",
+        "desc",
+        "digest",
+        "pkgbuild",
+        "prettyunits",
+        "rprojroot",
+        "sessioninfo",
+        "withr",
+        "xopen"
+      ]
     },
     "rematch2": {
       "Package": "rematch2",
       "Version": "2.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "76c9e04c712a05848ae7a23d2f170a40"
+      "Hash": "76c9e04c712a05848ae7a23d2f170a40",
+      "Requirements": [
+        "tibble"
+      ]
     },
     "remotes": {
       "Package": "remotes",
-      "Version": "2.4.1",
+      "Version": "2.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "feaca31e417db79fd1832e25b51a7717"
+      "Hash": "227045be9aee47e6dda9bb38ac870d67",
+      "Requirements": []
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.14.0",
+      "Version": "0.15.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "30e5eba91b67f7f4d75d31de14bbfbdc"
+      "Hash": "c1078316e1d4f70275fc1ea60c0bc431",
+      "Requirements": []
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "0.4.11",
+      "Version": "1.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "515f341d3affe0de9e4a7f762efb0456"
+      "Hash": "04884d9a75d778aca22c7154b8333ec9",
+      "Requirements": []
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.11",
+      "Version": "2.14",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "320017b52d05a943981272b295750388"
+      "Hash": "31b60a882fabfabf6785b8599ffeb8ba",
+      "Requirements": [
+        "bslib",
+        "evaluate",
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "knitr",
+        "stringr",
+        "tinytex",
+        "xfun",
+        "yaml"
+      ]
     },
     "roxygen2": {
       "Package": "roxygen2",
-      "Version": "7.1.2",
+      "Version": "7.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "eb9849556c4250305106e82edae35b72"
+      "Hash": "b390c1d54fcd977cda48588e6172daba",
+      "Requirements": [
+        "R6",
+        "brew",
+        "cli",
+        "commonmark",
+        "cpp11",
+        "desc",
+        "digest",
+        "knitr",
+        "pkgload",
+        "purrr",
+        "rlang",
+        "stringi",
+        "stringr",
+        "withr",
+        "xml2"
+      ]
     },
     "rprojroot": {
       "Package": "rprojroot",
-      "Version": "2.0.2",
+      "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "249d8cd1e74a8f6a26194a91b47f21d1"
+      "Hash": "1de7ab598047a87bba48434ba35d497d",
+      "Requirements": []
     },
     "rstudioapi": {
       "Package": "rstudioapi",
       "Version": "0.13",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
+      "Hash": "06c85365a03fdaf699966cc1d3cf53ea",
+      "Requirements": []
     },
     "rversions": {
       "Package": "rversions",
       "Version": "2.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f88fab00907b312f8b23ec13e2d437cb"
+      "Hash": "f88fab00907b312f8b23ec13e2d437cb",
+      "Requirements": [
+        "curl",
+        "xml2"
+      ]
     },
     "sass": {
       "Package": "sass",
-      "Version": "0.4.0",
+      "Version": "0.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "50cf822feb64bb3977bda0b7091be623"
+      "Hash": "f37c0028d720bab3c513fd65d28c7234",
+      "Requirements": [
+        "R6",
+        "fs",
+        "htmltools",
+        "rappdirs",
+        "rlang"
+      ]
     },
     "sessioninfo": {
       "Package": "sessioninfo",
-      "Version": "1.1.1",
+      "Version": "1.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "308013098befe37484df72c39cf90d6e"
+      "Hash": "3f9796a8d0a0e8c6eb49a4b029359d1f",
+      "Requirements": [
+        "cli"
+      ]
     },
     "shiny": {
       "Package": "shiny",
       "Version": "1.7.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "00344c227c7bd0ab5d78052c5d736c44"
+      "Hash": "00344c227c7bd0ab5d78052c5d736c44",
+      "Requirements": [
+        "R6",
+        "bslib",
+        "cachem",
+        "commonmark",
+        "crayon",
+        "ellipsis",
+        "fastmap",
+        "fontawesome",
+        "glue",
+        "htmltools",
+        "httpuv",
+        "jsonlite",
+        "later",
+        "lifecycle",
+        "mime",
+        "promises",
+        "rlang",
+        "sourcetools",
+        "withr",
+        "xtable"
+      ]
     },
     "sourcetools": {
       "Package": "sourcetools",
       "Version": "0.1.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "947e4e02a79effa5d512473e10f41797"
+      "Hash": "947e4e02a79effa5d512473e10f41797",
+      "Requirements": []
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.7.5",
+      "Version": "1.7.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "cd50dc9b449de3d3b47cdc9976886999"
+      "Hash": "bba431031d30789535745a9627ac9271",
+      "Requirements": []
     },
     "stringr": {
       "Package": "stringr",
       "Version": "1.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0759e6b6c0957edb1311028a49a35e76"
+      "Hash": "0759e6b6c0957edb1311028a49a35e76",
+      "Requirements": [
+        "glue",
+        "magrittr",
+        "stringi"
+      ]
     },
     "sys": {
       "Package": "sys",
       "Version": "3.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b227d13e29222b4574486cfcbde077fa"
+      "Hash": "b227d13e29222b4574486cfcbde077fa",
+      "Requirements": []
     },
     "systemfonts": {
       "Package": "systemfonts",
-      "Version": "1.0.2",
+      "Version": "1.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f2e17ba09737e2e7e2ec40fc1f9b6e08"
+      "Hash": "90b28393209827327de889f49935140a",
+      "Requirements": [
+        "cpp11"
+      ]
     },
     "testthat": {
       "Package": "testthat",
-      "Version": "3.1.0",
+      "Version": "3.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "89e55ebe4f5ddd7f43f0f2bc6d96c950"
+      "Hash": "f76c2a02d0fdc24aa7a47ea34261a6e3",
+      "Requirements": [
+        "R6",
+        "brio",
+        "callr",
+        "cli",
+        "crayon",
+        "desc",
+        "digest",
+        "ellipsis",
+        "evaluate",
+        "jsonlite",
+        "lifecycle",
+        "magrittr",
+        "pkgload",
+        "praise",
+        "processx",
+        "ps",
+        "rlang",
+        "waldo",
+        "withr"
+      ]
     },
     "textshaping": {
       "Package": "textshaping",
-      "Version": "0.3.5",
+      "Version": "0.3.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6bb7e974b464fe72f192e51b4dab67f2"
+      "Hash": "1ab6223d3670fac7143202cb6a2d43d5",
+      "Requirements": [
+        "cpp11",
+        "systemfonts"
+      ]
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.1.5",
+      "Version": "3.1.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "36eb05ad4cfdfeaa56f5a9b2a1311efd"
+      "Hash": "08415af406e3dd75049afef9552e7355",
+      "Requirements": [
+        "ellipsis",
+        "fansi",
+        "lifecycle",
+        "magrittr",
+        "pillar",
+        "pkgconfig",
+        "rlang",
+        "vctrs"
+      ]
     },
     "tidyr": {
       "Package": "tidyr",
-      "Version": "1.1.4",
+      "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c8fbdbd9fcac223d6c6fe8e406f368e1"
+      "Hash": "d8b95b7fee945d7da6888cf7eb71a49c",
+      "Requirements": [
+        "cpp11",
+        "dplyr",
+        "ellipsis",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "purrr",
+        "rlang",
+        "tibble",
+        "tidyselect",
+        "vctrs"
+      ]
     },
     "tidyselect": {
       "Package": "tidyselect",
-      "Version": "1.1.1",
+      "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "7243004a708d06d4716717fa1ff5b2fe"
+      "Hash": "17f6da8cfd7002760a859915ce7eef8f",
+      "Requirements": [
+        "ellipsis",
+        "glue",
+        "purrr",
+        "rlang",
+        "vctrs"
+      ]
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.34",
+      "Version": "0.38",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "043daa786f4d254f0031534150e28d42"
+      "Hash": "759d047596ac173433985deddf313450",
+      "Requirements": [
+        "xfun"
+      ]
     },
     "usethis": {
       "Package": "usethis",
-      "Version": "2.0.1",
+      "Version": "2.1.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "360e904f9e623286e1a0c6ca0a98c5f6"
+      "Hash": "c499f488e6dd7718accffaee5bc5a79b",
+      "Requirements": [
+        "cli",
+        "clipr",
+        "crayon",
+        "curl",
+        "desc",
+        "fs",
+        "gert",
+        "gh",
+        "glue",
+        "jsonlite",
+        "lifecycle",
+        "purrr",
+        "rappdirs",
+        "rlang",
+        "rprojroot",
+        "rstudioapi",
+        "whisker",
+        "withr",
+        "yaml"
+      ]
     },
     "utf8": {
       "Package": "utf8",
       "Version": "1.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c9c462b759a5cc844ae25b5942654d13"
+      "Hash": "c9c462b759a5cc844ae25b5942654d13",
+      "Requirements": []
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.3.8",
+      "Version": "0.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ecf749a1b39ea72bd9b51b76292261f1"
+      "Hash": "8b54f22e2a58c4f275479c92ce041a57",
+      "Requirements": [
+        "cli",
+        "glue",
+        "rlang"
+      ]
     },
     "visNetwork": {
       "Package": "visNetwork",
       "Version": "2.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "99b515a03efb8dcc4e4be337f37bf087"
+      "Hash": "99b515a03efb8dcc4e4be337f37bf087",
+      "Requirements": [
+        "htmltools",
+        "htmlwidgets",
+        "jsonlite",
+        "magrittr"
+      ]
     },
     "waldo": {
       "Package": "waldo",
-      "Version": "0.3.1",
+      "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ad8cfff5694ac5b3c354f8f2044bd976"
+      "Hash": "035fba89d0c86e2113120f93301b98ad",
+      "Requirements": [
+        "cli",
+        "diffobj",
+        "fansi",
+        "glue",
+        "rematch2",
+        "rlang",
+        "tibble"
+      ]
     },
     "whisker": {
       "Package": "whisker",
       "Version": "0.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ca970b96d894e90397ed20637a0c1bbe"
+      "Hash": "ca970b96d894e90397ed20637a0c1bbe",
+      "Requirements": []
     },
     "withr": {
       "Package": "withr",
-      "Version": "2.4.2",
+      "Version": "2.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ad03909b44677f930fa156d47d7a3aeb"
+      "Hash": "c0e49a9760983e81e55cdd9be92e7182",
+      "Requirements": []
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.26",
+      "Version": "0.31",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a270216f7ffda25e53298293046d1d05"
+      "Hash": "a318c6f752b8dcfe9fb74d897418ab2b",
+      "Requirements": []
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.3.2",
+      "Version": "1.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d4d71a75dd3ea9eb5fa28cc21f9585e2"
+      "Hash": "40682ed6a969ea5abfd351eb67833adc",
+      "Requirements": []
     },
     "xopen": {
       "Package": "xopen",
       "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6c85f015dee9cc7710ddd20f86881f58"
+      "Hash": "6c85f015dee9cc7710ddd20f86881f58",
+      "Requirements": [
+        "processx"
+      ]
     },
     "xtable": {
       "Package": "xtable",
       "Version": "1.8-4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2"
+      "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2",
+      "Requirements": []
     },
     "yaml": {
       "Package": "yaml",
-      "Version": "2.2.1",
+      "Version": "2.3.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2826c5d9efb0a88f657c7a679c7106db"
+      "Hash": "458bb38374d73bf83b1bb85e353da200",
+      "Requirements": []
     },
     "zip": {
       "Package": "zip",
       "Version": "2.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c7eef2996ac270a18c2715c997a727c5"
+      "Hash": "c7eef2996ac270a18c2715c997a727c5",
+      "Requirements": []
     }
   }
 }

--- a/renv.lock
+++ b/renv.lock
@@ -121,6 +121,22 @@
       "Hash": "2ba81b120c1655ab696c935ef33ea716",
       "Requirements": []
     },
+    "covr": {
+      "Package": "covr",
+      "Version": "3.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6d80a9fc3c0c8473153b54fa54719dfd",
+      "Requirements": [
+        "crayon",
+        "digest",
+        "httr",
+        "jsonlite",
+        "rex",
+        "withr",
+        "yaml"
+      ]
+    },
     "cpp11": {
       "Package": "cpp11",
       "Version": "0.4.2",
@@ -482,6 +498,14 @@
         "rlang"
       ]
     },
+    "lazyeval": {
+      "Package": "lazyeval",
+      "Version": "0.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d908914ae53b04d4c0c0fd72ecc35370",
+      "Requirements": []
+    },
     "lifecycle": {
       "Package": "lifecycle",
       "Version": "1.0.1",
@@ -764,6 +788,16 @@
       "Repository": "CRAN",
       "Hash": "c1078316e1d4f70275fc1ea60c0bc431",
       "Requirements": []
+    },
+    "rex": {
+      "Package": "rex",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ae34cd56890607370665bee5bd17812f",
+      "Requirements": [
+        "lazyeval"
+      ]
     },
     "rlang": {
       "Package": "rlang",

--- a/renv/.gitignore
+++ b/renv/.gitignore
@@ -1,3 +1,4 @@
+cellar/
 library/
 local/
 lock/

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,32 +2,50 @@
 local({
 
   # the requested version of renv
-  version <- "0.14.0"
+  version <- "0.15.4"
 
   # the project directory
   project <- getwd()
 
-  # allow environment variable to control activation
-  activate <- Sys.getenv("RENV_ACTIVATE_PROJECT")
-  if (!nzchar(activate)) {
+  # figure out whether the autoloader is enabled
+  enabled <- local({
 
-    # don't auto-activate when R CMD INSTALL is running
-    if (nzchar(Sys.getenv("R_INSTALL_PKG")))
-      return(FALSE)
+    # first, check config option
+    override <- getOption("renv.config.autoloader.enabled")
+    if (!is.null(override))
+      return(override)
 
-  }
+    # next, check environment variables
+    # TODO: prefer using the configuration one in the future
+    envvars <- c(
+      "RENV_CONFIG_AUTOLOADER_ENABLED",
+      "RENV_AUTOLOADER_ENABLED",
+      "RENV_ACTIVATE_PROJECT"
+    )
 
-  # bail if activation was explicitly disabled
-  if (tolower(activate) %in% c("false", "f", "0"))
+    for (envvar in envvars) {
+      envval <- Sys.getenv(envvar, unset = NA)
+      if (!is.na(envval))
+        return(tolower(envval) %in% c("true", "t", "1"))
+    }
+
+    # enable by default
+    TRUE
+
+  })
+
+  if (!enabled)
     return(FALSE)
 
   # avoid recursion
-  if (nzchar(Sys.getenv("RENV_R_INITIALIZING")))
+  if (identical(getOption("renv.autoloader.running"), TRUE)) {
+    warning("ignoring recursive attempt to run renv autoloader")
     return(invisible(TRUE))
+  }
 
   # signal that we're loading renv during R startup
-  Sys.setenv("RENV_R_INITIALIZING" = "true")
-  on.exit(Sys.unsetenv("RENV_R_INITIALIZING"), add = TRUE)
+  options(renv.autoloader.running = TRUE)
+  on.exit(options(renv.autoloader.running = NULL), add = TRUE)
 
   # signal that we've consented to use renv
   options(renv.consent = TRUE)
@@ -36,21 +54,15 @@ local({
   # mask 'utils' packages, will come first on the search path
   library(utils, lib.loc = .Library)
 
-  # check to see if renv has already been loaded
-  if ("renv" %in% loadedNamespaces()) {
-
-    # if renv has already been loaded, and it's the requested version of renv,
-    # nothing to do
-    spec <- .getNamespaceInfo(.getNamespace("renv"), "spec")
-    if (identical(spec[["version"]], version))
-      return(invisible(TRUE))
-
-    # otherwise, unload and attempt to load the correct version of renv
+  # unload renv if it's already been laoded
+  if ("renv" %in% loadedNamespaces())
     unloadNamespace("renv")
 
-  }
-
   # load bootstrap tools   
+  `%||%` <- function(x, y) {
+    if (is.environment(x) || length(x)) x else y
+  }
+  
   bootstrap <- function(version, library) {
   
     # attempt to download renv
@@ -74,6 +86,11 @@ local({
     # check for repos override
     repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
     if (!is.na(repos))
+      return(repos)
+  
+    # check for lockfile repositories
+    repos <- tryCatch(renv_bootstrap_repos_lockfile(), error = identity)
+    if (!inherits(repos, "error") && length(repos))
       return(repos)
   
     # if we're testing, re-use the test repositories
@@ -100,6 +117,30 @@ local({
   
   }
   
+  renv_bootstrap_repos_lockfile <- function() {
+  
+    lockpath <- Sys.getenv("RENV_PATHS_LOCKFILE", unset = "renv.lock")
+    if (!file.exists(lockpath))
+      return(NULL)
+  
+    lockfile <- tryCatch(renv_json_read(lockpath), error = identity)
+    if (inherits(lockfile, "error")) {
+      warning(lockfile)
+      return(NULL)
+    }
+  
+    repos <- lockfile$R$Repositories
+    if (length(repos) == 0)
+      return(NULL)
+  
+    keys <- vapply(repos, `[[`, "Name", FUN.VALUE = character(1))
+    vals <- vapply(repos, `[[`, "URL", FUN.VALUE = character(1))
+    names(vals) <- keys
+  
+    return(vals)
+  
+  }
+  
   renv_bootstrap_download <- function(version) {
   
     # if the renv version number has 4 components, assume it must
@@ -107,16 +148,20 @@ local({
     nv <- numeric_version(version)
     components <- unclass(nv)[[1]]
   
-    methods <- if (length(components) == 4L) {
-      list(
+    # if this appears to be a development version of 'renv', we'll
+    # try to restore from github
+    dev <- length(components) == 4L
+  
+    # begin collecting different methods for finding renv
+    methods <- c(
+      renv_bootstrap_download_tarball,
+      if (dev)
         renv_bootstrap_download_github
-      )
-    } else {
-      list(
+      else c(
         renv_bootstrap_download_cran_latest,
         renv_bootstrap_download_cran_archive
       )
-    }
+    )
   
     for (method in methods) {
       path <- tryCatch(method(version), error = identity)
@@ -253,6 +298,33 @@ local({
   
   }
   
+  renv_bootstrap_download_tarball <- function(version) {
+  
+    # if the user has provided the path to a tarball via
+    # an environment variable, then use it
+    tarball <- Sys.getenv("RENV_BOOTSTRAP_TARBALL", unset = NA)
+    if (is.na(tarball))
+      return()
+  
+    # allow directories
+    info <- file.info(tarball, extra_cols = FALSE)
+    if (identical(info$isdir, TRUE)) {
+      name <- sprintf("renv_%s.tar.gz", version)
+      tarball <- file.path(tarball, name)
+    }
+  
+    # bail if it doesn't exist
+    if (!file.exists(tarball))
+      return()
+  
+    fmt <- "* Bootstrapping with tarball at path '%s'."
+    msg <- sprintf(fmt, tarball)
+    message(msg)
+  
+    tarball
+  
+  }
+  
   renv_bootstrap_download_github <- function(version) {
   
     enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
@@ -306,7 +378,13 @@ local({
     bin <- R.home("bin")
     exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
     r <- file.path(bin, exe)
-    args <- c("--vanilla", "CMD", "INSTALL", "-l", shQuote(library), shQuote(tarball))
+  
+    args <- c(
+      "--vanilla", "CMD", "INSTALL", "--no-multiarch",
+      "-l", shQuote(path.expand(library)),
+      shQuote(path.expand(tarball))
+    )
+  
     output <- system2(r, args, stdout = TRUE, stderr = TRUE)
     message("Done!")
   
@@ -499,18 +577,33 @@ local({
   
   renv_bootstrap_library_root <- function(project) {
   
+    prefix <- renv_bootstrap_profile_prefix()
+  
     path <- Sys.getenv("RENV_PATHS_LIBRARY", unset = NA)
     if (!is.na(path))
-      return(path)
+      return(paste(c(path, prefix), collapse = "/"))
   
-    path <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
-    if (!is.na(path)) {
+    path <- renv_bootstrap_library_root_impl(project)
+    if (!is.null(path)) {
       name <- renv_bootstrap_library_root_name(project)
-      return(file.path(path, name))
+      return(paste(c(path, prefix, name), collapse = "/"))
     }
   
-    prefix <- renv_bootstrap_profile_prefix()
-    paste(c(project, prefix, "renv/library"), collapse = "/")
+    renv_bootstrap_paths_renv("library", project = project)
+  
+  }
+  
+  renv_bootstrap_library_root_impl <- function(project) {
+  
+    root <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
+    if (!is.na(root))
+      return(root)
+  
+    type <- renv_bootstrap_project_type(project)
+    if (identical(type, "package")) {
+      userdir <- renv_bootstrap_user_dir()
+      return(file.path(userdir, "library"))
+    }
   
   }
   
@@ -576,7 +669,7 @@ local({
       return(profile)
   
     # check for a profile file (nothing to do if it doesn't exist)
-    path <- file.path(project, "renv/local/profile")
+    path <- renv_bootstrap_paths_renv("profile", profile = FALSE)
     if (!file.exists(path))
       return(NULL)
   
@@ -587,7 +680,7 @@ local({
   
     # set RENV_PROFILE
     profile <- contents[[1L]]
-    if (nzchar(profile))
+    if (!profile %in% c("", "default"))
       Sys.setenv(RENV_PROFILE = profile)
   
     profile
@@ -597,7 +690,7 @@ local({
   renv_bootstrap_profile_prefix <- function() {
     profile <- renv_bootstrap_profile_get()
     if (!is.null(profile))
-      return(file.path("renv/profiles", profile))
+      return(file.path("profiles", profile, "renv"))
   }
   
   renv_bootstrap_profile_get <- function() {
@@ -619,6 +712,178 @@ local({
       return(NULL)
   
     profile
+  
+  }
+  
+  renv_bootstrap_path_absolute <- function(path) {
+  
+    substr(path, 1L, 1L) %in% c("~", "/", "\\") || (
+      substr(path, 1L, 1L) %in% c(letters, LETTERS) &&
+      substr(path, 2L, 3L) %in% c(":/", ":\\")
+    )
+  
+  }
+  
+  renv_bootstrap_paths_renv <- function(..., profile = TRUE, project = NULL) {
+    renv <- Sys.getenv("RENV_PATHS_RENV", unset = "renv")
+    root <- if (renv_bootstrap_path_absolute(renv)) NULL else project
+    prefix <- if (profile) renv_bootstrap_profile_prefix()
+    components <- c(root, renv, prefix, ...)
+    paste(components, collapse = "/")
+  }
+  
+  renv_bootstrap_project_type <- function(path) {
+  
+    descpath <- file.path(path, "DESCRIPTION")
+    if (!file.exists(descpath))
+      return("unknown")
+  
+    desc <- tryCatch(
+      read.dcf(descpath, all = TRUE),
+      error = identity
+    )
+  
+    if (inherits(desc, "error"))
+      return("unknown")
+  
+    type <- desc$Type
+    if (!is.null(type))
+      return(tolower(type))
+  
+    package <- desc$Package
+    if (!is.null(package))
+      return("package")
+  
+    "unknown"
+  
+  }
+  
+  renv_bootstrap_user_dir <- function() {
+    dir <- renv_bootstrap_user_dir_impl()
+    path.expand(chartr("\\", "/", dir))
+  }
+  
+  renv_bootstrap_user_dir_impl <- function() {
+  
+    # use local override if set
+    override <- getOption("renv.userdir.override")
+    if (!is.null(override))
+      return(override)
+  
+    # use R_user_dir if available
+    tools <- asNamespace("tools")
+    if (is.function(tools$R_user_dir))
+      return(tools$R_user_dir("renv", "cache"))
+  
+    # try using our own backfill for older versions of R
+    envvars <- c("R_USER_CACHE_DIR", "XDG_CACHE_HOME")
+    for (envvar in envvars) {
+      root <- Sys.getenv(envvar, unset = NA)
+      if (!is.na(root))
+        return(file.path(root, "R/renv"))
+    }
+  
+    # use platform-specific default fallbacks
+    if (Sys.info()[["sysname"]] == "Windows")
+      file.path(Sys.getenv("LOCALAPPDATA"), "R/cache/R/renv")
+    else if (Sys.info()[["sysname"]] == "Darwin")
+      "~/Library/Caches/org.R-project.R/R/renv"
+    else
+      "~/.cache/R/renv"
+  
+  }
+  
+  
+  renv_json_read <- function(file = NULL, text = NULL) {
+  
+    text <- paste(text %||% read(file), collapse = "\n")
+  
+    # find strings in the JSON
+    pattern <- '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
+    locs <- gregexpr(pattern, text)[[1]]
+  
+    # if any are found, replace them with placeholders
+    replaced <- text
+    strings <- character()
+    replacements <- character()
+  
+    if (!identical(c(locs), -1L)) {
+  
+      # get the string values
+      starts <- locs
+      ends <- locs + attr(locs, "match.length") - 1L
+      strings <- substring(text, starts, ends)
+  
+      # only keep those requiring escaping
+      strings <- grep("[[\\]{}:]", strings, perl = TRUE, value = TRUE)
+  
+      # compute replacements
+      replacements <- sprintf('"\032%i\032"', seq_along(strings))
+  
+      # replace the strings
+      mapply(function(string, replacement) {
+        replaced <<- sub(string, replacement, replaced, fixed = TRUE)
+      }, strings, replacements)
+  
+    }
+  
+    # transform the JSON into something the R parser understands
+    transformed <- replaced
+    transformed <- gsub("[[{]", "list(", transformed)
+    transformed <- gsub("[]}]", ")", transformed)
+    transformed <- gsub(":", "=", transformed, fixed = TRUE)
+    text <- paste(transformed, collapse = "\n")
+  
+    # parse it
+    json <- parse(text = text, keep.source = FALSE, srcfile = NULL)[[1L]]
+  
+    # construct map between source strings, replaced strings
+    map <- as.character(parse(text = strings))
+    names(map) <- as.character(parse(text = replacements))
+  
+    # convert to list
+    map <- as.list(map)
+  
+    # remap strings in object
+    remapped <- renv_json_remap(json, map)
+  
+    # evaluate
+    eval(remapped, envir = baseenv())
+  
+  }
+  
+  renv_json_remap <- function(json, map) {
+  
+    # fix names
+    if (!is.null(names(json))) {
+      lhs <- match(names(json), names(map), nomatch = 0L)
+      rhs <- match(names(map), names(json), nomatch = 0L)
+      names(json)[rhs] <- map[lhs]
+    }
+  
+    # fix values
+    if (is.character(json))
+      return(map[[json]] %||% json)
+  
+    # handle true, false, null
+    if (is.name(json)) {
+      text <- as.character(json)
+      if (text == "true")
+        return(TRUE)
+      else if (text == "false")
+        return(FALSE)
+      else if (text == "null")
+        return(NULL)
+    }
+  
+    # recurse
+    if (is.recursive(json)) {
+      for (i in seq_along(json)) {
+        json[i] <- list(renv_json_remap(json[[i]], map))
+      }
+    }
+  
+    json
   
   }
 

--- a/tests/testthat/test-renv.R
+++ b/tests/testthat/test-renv.R
@@ -1,0 +1,80 @@
+example_lockfile_text <-
+  '{
+      "R": {
+        "Version": "4.1.0",
+        "Repositories": [
+          {
+            "Name": "CRAN",
+            "URL": "https://cran.rstudio.com"
+          }
+        ]
+      },
+      "Packages": {
+        "R6": {
+          "Package": "R6",
+          "Version": "2.5.1",
+          "Source": "Repository",
+          "Repository": "CRAN",
+          "Hash": "470851b6d5d0ac559e9d01bb352b4021"
+        }
+      }
+    }'
+
+example_lockfile_text_2 <-
+  '{
+      "R": {
+        "Version": "4.0.3",
+        "Repositories": [
+          {
+            "Name": "CRAN",
+            "URL": "https://cran.rstudio.com"
+          }
+        ]
+      },
+      "Packages": {
+        "R6": {
+          "Package": "R6",
+          "Version": "2.5.1",
+          "Source": "Repository",
+          "Repository": "CRAN",
+          "Hash": "470851b6d5d0ac559e9d01bb352b4021"
+        }
+      }
+    }'
+
+test_that("get_renv_lock_from_repo_dir returns json lockfile if exists and profile is NULL", {
+  withr::with_tempdir({
+    write(example_lockfile_text, file = "renv.lock")
+    x <- get_renv_lock_from_repo_dir(".")
+    expect_equal(x, jsonlite::parse_json(example_lockfile_text))
+  })
+})
+
+test_that("get_renv_lock_from_repo_dir returns json lockfile from non NULL profile", {
+  withr::with_tempdir({
+    write(example_lockfile_text, file = "renv.lock")
+    fs::dir_create(fs::path_join(c(".", "renv", "profiles", "test")))
+    write(example_lockfile_text_2, file = fs::path_join(c(".", "renv", "profiles", "test", "renv.lock")))
+    x <- get_renv_lock_from_repo_dir(".", renv_profile = "test")
+    expect_equal(x, jsonlite::parse_json(example_lockfile_text_2))
+  })
+})
+
+test_that("get_renv_lock_from_repo_dir returns NULL if no lockfile" , {
+  withr::with_tempdir({
+    expect_null(get_renv_lock_from_repo_dir("."))
+    expect_null(get_renv_lock_from_repo_dir(".", renv_profile = "test"))
+    write(example_lockfile_text, file = "renv.lock")
+    expect_null(get_renv_lock_from_repo_dir(".", renv_profile = "test"))
+    fs::dir_create(fs::path_join(c(".", "renv", "profiles", "test")))
+    write(example_lockfile_text_2, file = fs::path_join(c(".", "renv", "profiles", "test", "renv.lock")))
+    expect_null(get_renv_lock_from_repo_dir(".", renv_profile = "other"))
+  })
+})
+
+test_that("get_renv_lock_from_repo_dir give warning and returns NULL if cannot read json of lockfile", {
+  withr::with_tempdir({
+    write("This is not JSON", file = "renv.lock")
+    expect_null(expect_warning(get_renv_lock_from_repo_dir(".")))
+  })
+})


### PR DESCRIPTION
Closes: https://github.com/openpharma/staged.dependencies/issues/147 and closes #146 
<img width="442" alt="image" src="https://user-images.githubusercontent.com/15201933/143031158-2c9f3e08-b619-473d-a171-f770f93071c8.png">

To test #147:

```
x <- dependency_table("openpharma/stageddeps.house", "repo@host", ref = "renv@main")
print(x$renv_files$stageddeps.house)
print(x$renv_files$stageddeps.food)
# test a profile which only exists on stageddeps.house:
x <- dependency_table("openpharma/stageddeps.house", "repo@host", ref = "profiles@renv@main", renv_profile = "example")
print(x$renv_files$stageddeps.house)
print(x$renv_files$stageddeps.food)
```


To test #146 

First run - outside of an renv environment:

```
x <- dependency_table("openpharma/stageddeps.house", "repo@host", ref = "renv@main") # could use "main" 
install_deps(x)
```

Then create an renv environment and make sure Bioconductor repos are in options("repos") and run the same command and you'll see the dependencies coming from the cache (or being installed into the cache if they are not already in the cache)
