### PR TITLE
use token_envvar for working out host type for additional error message

### DIFF
--- a/R/host.R
+++ b/R/host.R
@@ -1,9 +1,9 @@
 get_repo_access <- function(repo, host, token_envvar){
 
   host_type <- NULL
-  if (host == "https://github.com") {
+  if (host == "https://github.com" || token_envvar == "GITHUB_PAT") {
     host_type <- "github"
-  } else if (host %in% c("https://gitlab.com", "https://code.roche.com")) {
+  } else if (host == "https://gitlab.com" || token_envvar == "GITLAB_PAT") {
     host_type = "gitlab"
   } else {
     return(NULL)


### PR DESCRIPTION
This won't be a perfect way of working out which api to use, but should cover the main cases we need - it could be tackled more fully by #114 