### PR TITLE
Update R and BioC versions for E2E tests

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {image: ghcr.io/insightsengineering/rstudio_4.1.2_bioc_3.14, tag: latest}
+          - {image: ghcr.io/insightsengineering/rstudio_4.2.1_bioc_3.15, tag: latest}
     steps:
       - name: Install package
         run: >


### PR DESCRIPTION
So they use the same image as R CMD check.
